### PR TITLE
Model WinRT enums as structs

### DIFF
--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -20,7 +20,7 @@ pub fn import(stream: TokenStream) -> TokenStream {
     let stage = TypeStage::from_limits(reader, &limits);
     let tree = stage.into_tree();
     let stream = tree.to_tokens();
-    std::fs::write(r"c:\git\rust\dump.rs", stream.to_string()).unwrap();
+
     stream.into()
 }
 

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -20,7 +20,7 @@ pub fn import(stream: TokenStream) -> TokenStream {
     let stage = TypeStage::from_limits(reader, &limits);
     let tree = stage.into_tree();
     let stream = tree.to_tokens();
-
+    std::fs::write(r"c:\git\rust\dump.rs", stream.to_string()).unwrap();
     stream.into()
 }
 

--- a/crates/winmd/src/types/enum.rs
+++ b/crates/winmd/src/types/enum.rs
@@ -44,7 +44,6 @@ impl Enum {
     // avoid hte issue of duplicates below and also allow bit flags WinRT enums.
     pub fn to_tokens(&self) -> TokenStream {
         let name = self.name.to_tokens(&self.name.namespace);
-        let default = format_ident(&self.fields[0].0);
 
         let repr = match self.fields[0].1 {
             EnumConstant::U32(_) => format_ident!("u32"),
@@ -66,16 +65,12 @@ impl Enum {
 
         quote! {
             #[repr(transparent)]
-            #[derive(Copy, Clone, Debug, Eq, PartialEq)]
+            #[derive(Copy, Clone, Default, Debug, Eq, PartialEq)]
             pub struct #name {
                 value: #repr
             }
-            impl ::std::default::Default for #name {
-                fn default() -> Self {
-                    Self::#default
-                }
-            }
             impl #name {
+                #![allow(non_upper_case_globals)]
                 #(#fields)*
             }
             unsafe impl ::winrt::RuntimeType for #name {

--- a/crates/winmd/src/types/param.rs
+++ b/crates/winmd/src/types/param.rs
@@ -107,6 +107,7 @@ impl Param {
                     | TypeKind::Struct(_)
                     | TypeKind::Delegate(_)
                     | TypeKind::Generic(_) => quote! { #name.into().abi(), },
+                    TypeKind::Enum(_) => quote! { ::winrt::RuntimeType::abi(&#name), },
                     _ => quote! { ::winrt::RuntimeType::abi(#name), },
                 }
             }

--- a/crates/winmd/src/types/type_kind.rs
+++ b/crates/winmd/src/types/type_kind.rs
@@ -235,7 +235,7 @@ impl TypeKind {
             }
             Self::Enum(name) => {
                 let name = name.to_tokens(calling_namespace);
-                quote! { #name, }
+                quote! { <#name as ::winrt::RuntimeType>::Abi, }
             }
             Self::Struct(name) => {
                 let name = name.to_tokens(calling_namespace);
@@ -263,8 +263,7 @@ impl TypeKind {
             | Self::I64
             | Self::U64
             | Self::F32
-            | Self::F64
-            | Self::Enum(_) => true,
+            | Self::F64 => true,
 
             Self::String
             | Self::Object
@@ -273,6 +272,7 @@ impl TypeKind {
             | Self::Interface(_)
             | Self::Struct(_)
             | Self::Delegate(_)
+            | Self::Enum(_)
             | Self::Generic(_) => false,
         }
     }

--- a/tests/enum.rs
+++ b/tests/enum.rs
@@ -6,15 +6,17 @@ winrt::import!(
         "windows.application_model.appointments"
 );
 
+use winrt::RuntimeType;
+
 #[test]
 fn signed_enum() {
     use windows::foundation::AsyncStatus;
 
     assert!(AsyncStatus::default() == AsyncStatus::Canceled);
-    assert!(AsyncStatus::Canceled as i32 == 2);
-    assert!(AsyncStatus::Completed as i32 == 1);
-    assert!(AsyncStatus::Error as i32 == 3);
-    assert!(AsyncStatus::Started as i32 == 0);
+    assert!(AsyncStatus::Canceled.abi() == 2);
+    assert!(AsyncStatus::Completed.abi() == 1);
+    assert!(AsyncStatus::Error.abi() == 3);
+    assert!(AsyncStatus::Started.abi() == 0);
 }
 
 #[test]
@@ -22,16 +24,16 @@ fn unsigned_enum() {
     use windows::application_model::appointments::AppointmentDaysOfWeek;
 
     assert!(AppointmentDaysOfWeek::default() == AppointmentDaysOfWeek::None);
-    assert!(AppointmentDaysOfWeek::None as u32 == 0);
-    assert!(AppointmentDaysOfWeek::Sunday as u32 == 0x1);
-    assert!(AppointmentDaysOfWeek::Monday as u32 == 0x2);
-    assert!(AppointmentDaysOfWeek::Tuesday as u32 == 0x4);
-    assert!(AppointmentDaysOfWeek::Wednesday as u32 == 0x8);
-    assert!(AppointmentDaysOfWeek::Thursday as u32 == 0x10);
-    assert!(AppointmentDaysOfWeek::Friday as u32 == 0x20);
-    assert!(AppointmentDaysOfWeek::Saturday as u32 == 0x40);
+    assert!(AppointmentDaysOfWeek::None.abi() == 0);
+    assert!(AppointmentDaysOfWeek::Sunday.abi() == 0x1);
+    assert!(AppointmentDaysOfWeek::Monday.abi() == 0x2);
+    assert!(AppointmentDaysOfWeek::Tuesday.abi() == 0x4);
+    assert!(AppointmentDaysOfWeek::Wednesday.abi() == 0x8);
+    assert!(AppointmentDaysOfWeek::Thursday.abi() == 0x10);
+    assert!(AppointmentDaysOfWeek::Friday.abi() == 0x20);
+    assert!(AppointmentDaysOfWeek::Saturday.abi() == 0x40);
 
     // TODO: Unsigned WinRT enums are meant to be used as bit flags:
     // let weekend = AppointmentDaysOfWeek::Sunday | AppointmentDaysOfWeek::Saturday;
-    // assert!(weekend as u32 == 0x41);
+    // assert!(weekend.abi() == 0x41);
 }

--- a/tests/enum.rs
+++ b/tests/enum.rs
@@ -12,7 +12,7 @@ use winrt::RuntimeType;
 fn signed_enum() {
     use windows::foundation::AsyncStatus;
 
-    assert!(AsyncStatus::default() == AsyncStatus::Canceled);
+    assert!(AsyncStatus::default().abi() == 0);
     assert!(AsyncStatus::Canceled.abi() == 2);
     assert!(AsyncStatus::Completed.abi() == 1);
     assert!(AsyncStatus::Error.abi() == 3);
@@ -23,7 +23,7 @@ fn signed_enum() {
 fn unsigned_enum() {
     use windows::application_model::appointments::AppointmentDaysOfWeek;
 
-    assert!(AppointmentDaysOfWeek::default() == AppointmentDaysOfWeek::None);
+    assert!(AppointmentDaysOfWeek::default().abi() == 0);
     assert!(AppointmentDaysOfWeek::None.abi() == 0);
     assert!(AppointmentDaysOfWeek::Sunday.abi() == 0x1);
     assert!(AppointmentDaysOfWeek::Monday.abi() == 0x2);


### PR DESCRIPTION
Technically fixes #65 although I'll leave that issue open until I have finished the support for bitmask operators.