### PR TITLE
Add initial support for bitwise operations on WinRT enums

### DIFF
--- a/crates/winmd/src/types/enum.rs
+++ b/crates/winmd/src/types/enum.rs
@@ -82,6 +82,20 @@ impl Enum {
                     &mut self.value
                 }
             }
+            impl ::std::ops::BitOr for #name {
+                type Output = Self;
+
+                fn bitor(self, rhs: Self) -> Self {
+                    Self { value: self.value | rhs.value }
+                }
+            }
+            impl ::std::ops::BitAnd for #name {
+                type Output = Self;
+
+                fn bitand(self, rhs: Self) -> Self {
+                    Self { value: self.value & rhs.value }
+                }
+            }
         }
     }
 }

--- a/crates/winmd/src/types/enum.rs
+++ b/crates/winmd/src/types/enum.rs
@@ -50,10 +50,9 @@ impl Enum {
             EnumConstant::I32(_) => format_ident!("i32"),
         };
 
-        let fields = self.fields.iter().map(|field| {
-            let name = format_ident(&field.0);
-
-            let value = match field.1 {
+        let fields = self.fields.iter().map(|(name, value)| {
+            let name = format_ident(&name);
+            let value = match value {
                 EnumConstant::U32(value) => quote! { #value },
                 EnumConstant::I32(value) => quote! { #value },
             };
@@ -62,6 +61,7 @@ impl Enum {
                 pub const #name: Self = Self { value: #value };
             }
         });
+        let bitwise = bitwise_operators(&name, &self.fields[0].1);
 
         quote! {
             #[repr(transparent)]
@@ -82,19 +82,29 @@ impl Enum {
                     &mut self.value
                 }
             }
-            impl ::std::ops::BitOr for #name {
-                type Output = Self;
+            #bitwise
+        }
+    }
+}
 
-                fn bitor(self, rhs: Self) -> Self {
-                    Self { value: self.value | rhs.value }
-                }
+fn bitwise_operators(name: &TokenStream, value_type: &EnumConstant) -> TokenStream {
+    if matches!(value_type, EnumConstant::I32(_)) {
+        return quote! {};
+    }
+
+    quote! {
+        impl ::std::ops::BitOr for #name {
+            type Output = Self;
+
+            fn bitor(self, rhs: Self) -> Self {
+                Self { value: self.value | rhs.value }
             }
-            impl ::std::ops::BitAnd for #name {
-                type Output = Self;
+        }
+        impl ::std::ops::BitAnd for #name {
+            type Output = Self;
 
-                fn bitand(self, rhs: Self) -> Self {
-                    Self { value: self.value & rhs.value }
-                }
+            fn bitand(self, rhs: Self) -> Self {
+                Self { value: self.value & rhs.value }
             }
         }
     }

--- a/tests/enum.rs
+++ b/tests/enum.rs
@@ -33,7 +33,7 @@ fn unsigned_enum() {
     assert!(AppointmentDaysOfWeek::Friday.abi() == 0x20);
     assert!(AppointmentDaysOfWeek::Saturday.abi() == 0x40);
 
-    // TODO: Unsigned WinRT enums are meant to be used as bit flags:
-    // let weekend = AppointmentDaysOfWeek::Sunday | AppointmentDaysOfWeek::Saturday;
-    // assert!(weekend.abi() == 0x41);
+    // Use as bitflags
+    let weekend = AppointmentDaysOfWeek::Sunday | AppointmentDaysOfWeek::Saturday;
+    assert!(weekend.abi() == 0x41);
 }


### PR DESCRIPTION
Fixes #115. 

This only adds support for `&` and `|`. We need to decide if every enum should support `&=`, `|=`, `^`, and `^=`.