### PR TITLE
Add default target for docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ members = [
 
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"
+targets = ["x86_64-pc-windows-msvc", "i686-pc-windows-msvc"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,6 @@ winrt_macros = { path = "crates/macros" }
 members = [
     "crates/*",
 ]
+
+[package.metadata.docs.rs]
+default-target = "x86_64-pc-windows-msvc"


### PR DESCRIPTION
So we'll land on windows documentation when browsing it on docs.rs. Question though: Do you want to only build for windows targets? If so, I can just list the windows targets (there are 2 on docs.rs) and that will be it.