### PR TITLE
Enforce README examples testing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ repository = "https://github.com/microsoft/winrt-rs"
 [dependencies]
 winrt_macros = { path = "crates/macros" }
 
+[dev-dependencies]
+doc-comment = "0.3"
+
 [workspace]
 members = [
     "crates/*",

--- a/README.md
+++ b/README.md
@@ -17,11 +17,10 @@ winrt = { git = "https://github.com/microsoft/winrt-rs" }
 
 This will allow Cargo to download, build, and cache the Rust/WinRT support as a package directly from GitHub.
 
-Now use the `import` macro to import the desired winmd files and modules:
-
 ```rust
 use winrt::*;
 
+// Now use the `import` macro to import the desired winmd files and modules:
 import!(
     dependencies
         "os"
@@ -30,12 +29,10 @@ import!(
         "windows.foundation"
         "windows.ui"
 );
-```
 
-Finally, make use of any WinRT APIs as needed. For example, here is an example of using the `XmlDocument` class to parse an XML document:
-
-```rust
 fn main() -> Result<()> {
+    // Finally, make use of any WinRT APIs as needed. For example, here is
+    // an example of using the `XmlDocument` class to parse an XML document:
     use windows::data::xml::dom::*;
 
     let doc = XmlDocument::new()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,9 @@
 //! string: http://kennykerr.ca/
 //! ```
 
+#[cfg(doctest)]
+doc_comment::doctest!("../README.md");
+
 #[doc(hidden)]
 pub mod activation;
 mod array;


### PR DESCRIPTION
It's pretty common to have README examples out of date. With this, their testing will be enforced when running "rustdoc --test" (or just "cargo test").