### PR TITLE
Basic delegate support

### DIFF
--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -22,7 +22,7 @@ pub fn import(stream: TokenStream) -> TokenStream {
     let stage = TypeStage::from_limits(reader, &limits);
     let tree = stage.into_tree();
     let stream = tree.to_tokens();
-    std::fs::write(r"c:\git\rust\dump.rs", stream.to_string()).unwrap();
+    //std::fs::write(r"c:\git\rust\dump.rs", stream.to_string()).unwrap();
     stream.into()
 }
 

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -22,7 +22,7 @@ pub fn import(stream: TokenStream) -> TokenStream {
     let stage = TypeStage::from_limits(reader, &limits);
     let tree = stage.into_tree();
     let stream = tree.to_tokens();
-
+    std::fs::write(r"c:\git\rust\dump.rs", stream.to_string()).unwrap();
     stream.into()
 }
 

--- a/crates/winmd/src/lib.rs
+++ b/crates/winmd/src/lib.rs
@@ -25,10 +25,6 @@ fn format_ident(name: &str) -> proc_macro2::Ident {
     }
 }
 
-fn format_abi_ident(name: &str) -> proc_macro2::Ident {
-    quote::format_ident!("abi_{}", name)
-}
-
 #[cfg(target_pointer_width = "64")]
 const SYSTEM32: &str = "System32";
 

--- a/crates/winmd/src/types/delegate.rs
+++ b/crates/winmd/src/types/delegate.rs
@@ -34,6 +34,7 @@ impl Delegate {
         let name = self.name.to_tokens(&self.name.namespace);
         let phantoms = self.name.phantoms();
         let constraints = self.name.constraints();
+        let method = self.method.to_default_tokens(&self.name.namespace);
         let abi_method = self.method.to_abi_tokens(&self.name, &self.name.namespace);
         let guid = self.guid.to_tokens();
 
@@ -43,6 +44,9 @@ impl Delegate {
             pub struct #definition where #constraints {
                 ptr: ::winrt::ComPtr<#name>,
                 #phantoms
+            }
+            impl<#constraints> #name {
+                #method
             }
             unsafe impl<#constraints> ::winrt::ComInterface for #name {
                 type VTable = #abi_definition;

--- a/crates/winmd/src/types/delegate.rs
+++ b/crates/winmd/src/types/delegate.rs
@@ -88,6 +88,24 @@ impl Delegate {
             }
             impl<#constraints #fn_constraint> #impl_name {
 
+                extern "system" fn unknown_add_ref(this: ::winrt::RawComPtr<::winrt::IUnknown>) -> u32 {
+                    unsafe {
+                        let this = this as *const Self as *mut Self;
+                        (*this).count.add_ref()
+                    }
+                }
+                extern "system" fn unknown_release(this: ::winrt::RawComPtr<::winrt::IUnknown>) -> u32 {
+                    unsafe {
+                        let this = this as *const Self as *mut Self;
+                        let remaining = (*this).count.release();
+            
+                        if remaining == 0 {
+                            Box::from_raw(this);
+                        }
+            
+                        remaining
+                    }
+                }
             }
         }
     }
@@ -115,7 +133,7 @@ impl Delegate {
         }
     }
 
-    pub fn to_impl_name_tokens(&self) -> TokenStream {
+    fn to_impl_name_tokens(&self) -> TokenStream {
         if self.name.generics.is_empty() {
             let name = format_impl_ident(&self.name.name);
             quote! { #name<F> }

--- a/crates/winmd/src/types/delegate.rs
+++ b/crates/winmd/src/types/delegate.rs
@@ -78,19 +78,23 @@ impl Delegate {
                     self.ptr.set_abi()
                 }
             }
+            #[repr(C)]
+            struct #impl_definition where #constraints {
+                vtable: *const #abi_definition,
+                count: ::winrt::RefCount,
+                invoke: F,
+            }
         }
     }
 
     pub fn to_impl_definition_tokens(&self) -> TokenStream {
-        let namespace = to_namespace_tokens(&self.name.namespace, &self.name.namespace);
-
         if self.name.generics.is_empty() {
             let name = format_impl_ident(&self.name.name);
-            quote! { #namespace#name }
+            quote! { #name<F: FnMut() -> ::winrt::Result<()>> }
         } else {
             let name = format_impl_ident(&self.name.name[..self.name.name.len() - 2]);
             let generics = self.name.generics.iter().map(|g| g.to_tokens(&self.name.namespace));
-            quote! { #namespace#name<#(#generics),*> }
+            quote! { #name<#(#generics,)* F: FnMut() -> ::winrt::Result<()>> }
         }
     }
 }

--- a/crates/winmd/src/types/delegate.rs
+++ b/crates/winmd/src/types/delegate.rs
@@ -41,6 +41,7 @@ impl Delegate {
         let abi_method = self.method.to_abi_tokens(&self.name, &self.name.namespace);
         let guid = self.guid.to_tokens();
         let invoke_sig = self.method.to_abi_impl_tokens(&self.name, &self.name.namespace);
+        let invoke_args = self.method.params.iter().map(|param| param.to_invoke_arg_tokens());
 
         quote! {
             #[repr(transparent)]
@@ -131,7 +132,8 @@ impl Delegate {
                 #invoke_sig {
                     unsafe {
                         let this = this as *const Self as *mut Self;
-                        ::winrt::ErrorCode(0)
+                        ((*this).invoke)(#(#invoke_args,)*).into()
+                        //::winrt::ErrorCode(0)
                     }
                 }
             }

--- a/crates/winmd/src/types/delegate.rs
+++ b/crates/winmd/src/types/delegate.rs
@@ -40,6 +40,7 @@ impl Delegate {
         let method = self.method.to_default_tokens(&self.name.namespace);
         let abi_method = self.method.to_abi_tokens(&self.name, &self.name.namespace);
         let guid = self.guid.to_tokens();
+        let invoke_sig = self.method.to_abi_impl_tokens(&self.name, &self.name.namespace);
 
         quote! {
             #[repr(transparent)]
@@ -127,7 +128,7 @@ impl Delegate {
                         remaining
                     }
                 }
-                extern "system" fn invoke(this: *const *const #abi_definition) -> ::winrt::ErrorCode {
+                #invoke_sig {
                     unsafe {
                         let this = this as *const Self as *mut Self;
                         ::winrt::ErrorCode(0)

--- a/crates/winmd/src/types/delegate.rs
+++ b/crates/winmd/src/types/delegate.rs
@@ -41,8 +41,14 @@ impl Delegate {
         let method = self.method.to_default_tokens(&self.name.namespace);
         let abi_method = self.method.to_abi_tokens(&self.name, &self.name.namespace);
         let guid = self.guid.to_tokens();
-        let invoke_sig = self.method.to_abi_impl_tokens(&self.name, &self.name.namespace);
-        let invoke_args = self.method.params.iter().map(|param| param.to_invoke_arg_tokens());
+        let invoke_sig = self
+            .method
+            .to_abi_impl_tokens(&self.name, &self.name.namespace);
+        let invoke_args = self
+            .method
+            .params
+            .iter()
+            .map(|param| param.to_invoke_arg_tokens());
 
         quote! {
             #[repr(transparent)]
@@ -119,7 +125,7 @@ impl Delegate {
                 ) -> ::winrt::ErrorCode {
                     unsafe {
                         let this = this as *const Self as *mut Self;
-            
+
                         if *iid == <#name as ::winrt::ComInterface>::IID
                             || *iid == <::winrt::IUnknown as ::winrt::ComInterface>::IID
                             || *iid == <::winrt::IAgileObject as ::winrt::ComInterface>::IID
@@ -128,7 +134,7 @@ impl Delegate {
                             (*this).count.add_ref();
                             return ::winrt::ErrorCode(0);
                         }
-            
+
                         *interface = std::ptr::null_mut();
                         ::winrt::ErrorCode(0x80004002)
                     }
@@ -143,11 +149,11 @@ impl Delegate {
                     unsafe {
                         let this = this as *const Self as *mut Self;
                         let remaining = (*this).count.release();
-            
+
                         if remaining == 0 {
                             Box::from_raw(this);
                         }
-            
+
                         remaining
                     }
                 }
@@ -162,7 +168,11 @@ impl Delegate {
     }
 
     fn to_fn_constraint_tokens(&self) -> TokenStream {
-        let params = self.method.params.iter().map(|param| param.to_fn_tokens(&self.name.namespace));
+        let params = self
+            .method
+            .params
+            .iter()
+            .map(|param| param.to_fn_tokens(&self.name.namespace));
 
         let return_type = if let Some(return_type) = &self.method.return_type {
             return_type.to_return_tokens(&self.name.namespace)
@@ -179,7 +189,11 @@ impl Delegate {
             quote! { #name<#fn_constraint> }
         } else {
             let name = format_impl_ident(&self.name.name[..self.name.name.len() - 2]);
-            let generics = self.name.generics.iter().map(|g| g.to_tokens(&self.name.namespace));
+            let generics = self
+                .name
+                .generics
+                .iter()
+                .map(|g| g.to_tokens(&self.name.namespace));
             quote! { #name<#(#generics,)* #fn_constraint> }
         }
     }
@@ -190,7 +204,11 @@ impl Delegate {
             quote! { #name::<F> }
         } else {
             let name = format_impl_ident(&self.name.name[..self.name.name.len() - 2]);
-            let generics = self.name.generics.iter().map(|g| g.to_tokens(&self.name.namespace));
+            let generics = self
+                .name
+                .generics
+                .iter()
+                .map(|g| g.to_tokens(&self.name.namespace));
             quote! { #name::<#(#generics,)* F> }
         }
     }

--- a/crates/winmd/src/types/delegate.rs
+++ b/crates/winmd/src/types/delegate.rs
@@ -31,6 +31,7 @@ impl Delegate {
     pub fn to_tokens(&self) -> TokenStream {
         let definition = self.name.to_definition_tokens(&self.name.namespace);
         let abi_definition = self.name.to_abi_definition_tokens(&self.name.namespace);
+        let impl_definition = self.to_impl_definition_tokens();
         let name = self.name.to_tokens(&self.name.namespace);
         let phantoms = self.name.phantoms();
         let constraints = self.name.constraints();
@@ -79,4 +80,21 @@ impl Delegate {
             }
         }
     }
+
+    pub fn to_impl_definition_tokens(&self) -> TokenStream {
+        let namespace = to_namespace_tokens(&self.name.namespace, &self.name.namespace);
+
+        if self.name.generics.is_empty() {
+            let name = format_impl_ident(&self.name.name);
+            quote! { #namespace#name }
+        } else {
+            let name = format_impl_ident(&self.name.name[..self.name.name.len() - 2]);
+            let generics = self.name.generics.iter().map(|g| g.to_tokens(&self.name.namespace));
+            quote! { #namespace#name<#(#generics),*> }
+        }
+    }
+}
+
+fn format_impl_ident(name: &str) -> proc_macro2::Ident {
+    quote::format_ident!("impl_{}", name)
 }

--- a/crates/winmd/src/types/delegate.rs
+++ b/crates/winmd/src/types/delegate.rs
@@ -58,8 +58,7 @@ impl Delegate {
             }
             #[repr(C)]
             pub struct #abi_definition where #constraints {
-                pub unknown_query_interface:
-                extern "system" fn(::winrt::RawComPtr<::winrt::IUnknown>, &::winrt::Guid, *mut ::winrt::RawPtr) -> ::winrt::ErrorCode,
+                pub unknown_query_interface: extern "system" fn(::winrt::RawComPtr<::winrt::IUnknown>, &::winrt::Guid, *mut ::winrt::RawPtr) -> ::winrt::ErrorCode,
                 pub unknown_add_ref: extern "system" fn(::winrt::RawComPtr<::winrt::IUnknown>) -> u32,
                 pub unknown_release: extern "system" fn(::winrt::RawComPtr<::winrt::IUnknown>) -> u32,
                 #abi_method

--- a/crates/winmd/src/types/delegate.rs
+++ b/crates/winmd/src/types/delegate.rs
@@ -41,7 +41,7 @@ impl Delegate {
             #[repr(transparent)]
             #[derive(Default)]
             pub struct #definition where #constraints {
-                ptr: ::winrt::IUnknown,
+                ptr: ::winrt::ComPtr<#name>,
                 #phantoms
             }
             unsafe impl<#constraints> ::winrt::ComInterface for #name {
@@ -58,17 +58,20 @@ impl Delegate {
             }
             #[repr(C)]
             pub struct #abi_definition where #constraints {
-                __base: [usize; 6],
+                pub unknown_query_interface:
+                extern "system" fn(::winrt::RawComPtr<::winrt::IUnknown>, &::winrt::Guid, *mut ::winrt::RawPtr) -> ::winrt::ErrorCode,
+                pub unknown_add_ref: extern "system" fn(::winrt::RawComPtr<::winrt::IUnknown>) -> u32,
+                pub unknown_release: extern "system" fn(::winrt::RawComPtr<::winrt::IUnknown>) -> u32,
                 #abi_method
                 #phantoms
             }
             unsafe impl<#constraints> ::winrt::RuntimeType for #name {
-                type Abi = ::winrt::RawPtr;
+                type Abi = ::winrt::RawComPtr<Self>;
                 fn abi(&self) -> Self::Abi {
-                     <::winrt::IUnknown as ::winrt::ComInterface>::as_raw(&self.ptr) as Self::Abi
+                    <::winrt::ComPtr<Self> as ::winrt::ComInterface>::as_raw(&self.ptr)
                 }
                 fn set_abi(&mut self) -> *mut Self::Abi {
-                    self.ptr.set_abi() as _
+                    self.ptr.set_abi()
                 }
             }
         }

--- a/crates/winmd/src/types/delegate.rs
+++ b/crates/winmd/src/types/delegate.rs
@@ -88,6 +88,27 @@ impl Delegate {
             }
             impl<#constraints #fn_constraint> #impl_name {
 
+                extern "system" fn unknown_query_interface(
+                    this: ::winrt::RawComPtr<::winrt::IUnknown>,
+                    iid: &::winrt::Guid,
+                    interface: *mut ::winrt::RawPtr,
+                ) -> ::winrt::ErrorCode {
+                    unsafe {
+                        let this = this as *const Self as *mut Self;
+            
+                        if *iid == <#name as ::winrt::ComInterface>::IID
+                            || *iid == <::winrt::IUnknown as ::winrt::ComInterface>::IID
+                            || *iid == <::winrt::IAgileObject as ::winrt::ComInterface>::IID
+                        {
+                            *interface = this as ::winrt::RawPtr;
+                            (*this).count.add_ref();
+                            return ::winrt::ErrorCode(0);
+                        }
+            
+                        *interface = std::ptr::null_mut();
+                        ::winrt::ErrorCode(0x80004002)
+                    }
+                }
                 extern "system" fn unknown_add_ref(this: ::winrt::RawComPtr<::winrt::IUnknown>) -> u32 {
                     unsafe {
                         let this = this as *const Self as *mut Self;

--- a/crates/winmd/src/types/delegate.rs
+++ b/crates/winmd/src/types/delegate.rs
@@ -53,6 +53,9 @@ impl Delegate {
             }
             impl<#constraints> #name {
                 #method
+                pub fn new<#fn_constraint>(invoke: F) -> Self {
+                    #impl_name::new(invoke)
+                }
             }
             unsafe impl<#constraints> ::winrt::ComInterface for #name {
                 type VTable = #abi_definition;
@@ -97,6 +100,18 @@ impl Delegate {
                     invoke: #impl_name::invoke,
                     #phantoms
                 };
+                pub fn new(invoke: F) -> #name {
+                    let value = Self {
+                        vtable: &Self::VTABLE,
+                        count: ::winrt::RefCount::new(1),
+                        invoke,
+                    };
+                    unsafe {
+                        let mut result: #name = std::mem::zeroed();
+                        *<#name as ::winrt::RuntimeType>::set_abi(&mut result) = ::std::boxed::Box::into_raw(::std::boxed::Box::new(value)) as *const *const #abi_definition;
+                        result
+                    }
+                }
                 extern "system" fn unknown_query_interface(
                     this: ::winrt::RawComPtr<::winrt::IUnknown>,
                     iid: &::winrt::Guid,

--- a/crates/winmd/src/types/delegate.rs
+++ b/crates/winmd/src/types/delegate.rs
@@ -127,6 +127,12 @@ impl Delegate {
                         remaining
                     }
                 }
+                extern "system" fn invoke(this: *const *const #abi_definition) -> ::winrt::ErrorCode {
+                    unsafe {
+                        let this = this as *const Self as *mut Self;
+                        ::winrt::ErrorCode(0)
+                    }
+                }
             }
         }
     }

--- a/crates/winmd/src/types/interface.rs
+++ b/crates/winmd/src/types/interface.rs
@@ -85,7 +85,12 @@ impl Interface {
             }
             #[repr(C)]
             pub struct #abi_definition where #constraints {
-                __base: [usize; 6],
+                pub unknown_query_interface: extern "system" fn(::winrt::RawComPtr<::winrt::IUnknown>, &::winrt::Guid, *mut ::winrt::RawPtr) -> ::winrt::ErrorCode,
+                pub unknown_add_ref: extern "system" fn(::winrt::RawComPtr<::winrt::IUnknown>) -> u32,
+                pub unknown_release: extern "system" fn(::winrt::RawComPtr<::winrt::IUnknown>) -> u32,
+                pub inspectable_iids: extern "system" fn(::winrt::RawComPtr<::winrt::Object>, *mut u32, *mut *mut ::winrt::Guid) -> ::winrt::ErrorCode,
+                pub inspectable_type_name: extern "system" fn(::winrt::RawComPtr<::winrt::Object>, *mut <::winrt::HString as ::winrt::RuntimeType>::Abi) -> ::winrt::ErrorCode,
+                pub inspectable_trust_level: extern "system" fn(::winrt::RawComPtr<::winrt::Object>, *mut i32) -> ::winrt::ErrorCode,
                 #abi_methods
                 #phantoms
             }

--- a/crates/winmd/src/types/method.rs
+++ b/crates/winmd/src/types/method.rs
@@ -150,16 +150,15 @@ impl Method {
     pub fn to_abi_impl_tokens(&self, self_name: &TypeName, calling_namespace: &str) -> TokenStream {
         let abi_name = self_name.to_abi_tokens(calling_namespace);
         let name = format_ident(&self.name);
-        let params = 
-            self.params
-                .iter()
-                .chain(self.return_type.iter())
-                .map(|param| {
-                    let name = format_ident(&param.name);
-                    let abi = param.to_abi_tokens(calling_namespace);
-                    quote! { #name: #abi }
-                });
-
+        let params = self
+            .params
+            .iter()
+            .chain(self.return_type.iter())
+            .map(|param| {
+                let name = format_ident(&param.name);
+                let abi = param.to_abi_tokens(calling_namespace);
+                quote! { #name: #abi }
+            });
 
         quote! {
             extern "system" fn #name(this: *const *const #abi_name, #(#params)*) -> ::winrt::ErrorCode

--- a/crates/winmd/src/types/method.rs
+++ b/crates/winmd/src/types/method.rs
@@ -66,7 +66,7 @@ impl Method {
         let return_type = if blob.read_expected(0x01) {
             None
         } else {
-            let name = String::new();
+            let name = "__result".to_owned();
             let array = blob.peek_unsigned().0 == 0x1D;
             let kind = TypeKind::from_blob(&mut blob, generics);
             let input = false;

--- a/crates/winmd/src/types/method.rs
+++ b/crates/winmd/src/types/method.rs
@@ -147,6 +147,25 @@ impl Method {
         }
     }
 
+    pub fn to_abi_impl_tokens(&self, self_name: &TypeName, calling_namespace: &str) -> TokenStream {
+        let abi_name = self_name.to_abi_tokens(calling_namespace);
+        let name = format_ident(&self.name);
+        let params = 
+            self.params
+                .iter()
+                .chain(self.return_type.iter())
+                .map(|param| {
+                    let name = format_ident(&param.name);
+                    let abi = param.to_abi_tokens(calling_namespace);
+                    quote! { #name: #abi }
+                });
+
+
+        quote! {
+            extern "system" fn #name(this: *const *const #abi_name, #(#params)*) -> ::winrt::ErrorCode
+        }
+    }
+
     fn to_param_tokens(&self, calling_namespace: &str) -> TokenStream {
         TokenStream::from_iter(
             self.params

--- a/crates/winmd/src/types/param.rs
+++ b/crates/winmd/src/types/param.rs
@@ -155,13 +155,6 @@ impl Param {
             // TODO: delegate with array parameters are challenging to say the least.
             // I'll get to them shortly.
             panic!("array");
-            // if self.input {
-            //
-            // } else if self.by_ref {
-            //
-            // } else {
-            //
-            // }
         } else if self.input {
             match self.kind {
                 TypeKind::Enum(_) => quote! { *::winrt::RuntimeType::from_abi(&#name) },

--- a/crates/winmd/src/types/param.rs
+++ b/crates/winmd/src/types/param.rs
@@ -152,20 +152,21 @@ impl Param {
         let name = format_ident(&self.name);
 
         if self.array {
+            // TODO: delegate with array parameters are challenging to say the least.
+            // I'll get to them shortly.
             panic!("array");
             // if self.input {
-            //     quote! { #name.len() as u32, ::std::mem::transmute(#name.as_ptr()), }
+            //
             // } else if self.by_ref {
-            //     quote! { #name.set_abi_len(), #name.set_abi(), }
+            //
             // } else {
-            //     quote! { #name.len() as u32, ::std::mem::transmute_copy(&#name), }
+            //
             // }
         } else if self.input {
             match self.kind {
                 TypeKind::Enum(_) => quote! { *::winrt::RuntimeType::from_abi(&#name) },
                 _ => quote! { ::winrt::RuntimeType::from_abi(&#name) },
             }
-            
         } else if self.kind.blittable() {
             quote! { #name, }
         } else {

--- a/crates/winmd/src/types/param.rs
+++ b/crates/winmd/src/types/param.rs
@@ -45,6 +45,36 @@ impl Param {
         }
     }
 
+    pub fn to_fn_tokens(&self, calling_namespace: &str) -> TokenStream {
+        let tokens = self.kind.to_tokens(calling_namespace);
+
+        if self.array {
+            if self.input {
+                quote! { &[#tokens], }
+            } else if self.by_ref {
+                quote! { &mut ::winrt::Array<#tokens>, }
+            } else {
+                quote! { &mut [#tokens], }
+            }
+        } else if self.input {
+            match self.kind {
+                TypeKind::String
+                | TypeKind::Object
+                | TypeKind::Guid
+                | TypeKind::Class(_)
+                | TypeKind::Interface(_)
+                | TypeKind::Struct(_)
+                | TypeKind::Delegate(_)
+                | TypeKind::Generic(_) => {
+                    quote! { &#tokens, }
+                }
+                _ => quote! { #tokens, },
+            }
+        } else {
+            quote! { &mut #tokens, }
+        }
+    }
+
     pub fn to_return_tokens(&self, calling_namespace: &str) -> TokenStream {
         let tokens = self.kind.to_tokens(calling_namespace);
 

--- a/crates/winmd/src/types/param.rs
+++ b/crates/winmd/src/types/param.rs
@@ -147,4 +147,29 @@ impl Param {
             quote! { ::winrt::RuntimeType::set_abi(#name), }
         }
     }
+
+    pub fn to_invoke_arg_tokens(&self) -> TokenStream {
+        let name = format_ident(&self.name);
+
+        if self.array {
+            panic!("array");
+            // if self.input {
+            //     quote! { #name.len() as u32, ::std::mem::transmute(#name.as_ptr()), }
+            // } else if self.by_ref {
+            //     quote! { #name.set_abi_len(), #name.set_abi(), }
+            // } else {
+            //     quote! { #name.len() as u32, ::std::mem::transmute_copy(&#name), }
+            // }
+        } else if self.input {
+            match self.kind {
+                TypeKind::Enum(_) => quote! { *::winrt::RuntimeType::from_abi(&#name) },
+                _ => quote! { ::winrt::RuntimeType::from_abi(&#name) },
+            }
+            
+        } else if self.kind.blittable() {
+            quote! { #name, }
+        } else {
+            quote! { ::winrt::RuntimeType::from_mut_abi(#name) }
+        }
+    }
 }

--- a/crates/winmd/src/types/type_kind.rs
+++ b/crates/winmd/src/types/type_kind.rs
@@ -218,32 +218,23 @@ impl TypeKind {
             Self::U64 => quote! { u64, },
             Self::F32 => quote! { f32, },
             Self::F64 => quote! { f64, },
+            Self::Guid => quote! { ::winrt::Guid, },
             Self::String => {
                 quote! { <::winrt::HString as ::winrt::RuntimeType>::Abi, }
             }
             Self::Object => {
                 quote! { <::winrt::Object as ::winrt::RuntimeType>::Abi, }
             }
-            Self::Guid => quote! { ::winrt::Guid, },
-            Self::Class(c) => {
-                let name = c.to_tokens(calling_namespace);
-                quote! { <#name as ::winrt::RuntimeType>::Abi, }
-            }
-            Self::Interface(i) => {
-                let name = i.to_tokens(calling_namespace);
-                quote! { <#name as ::winrt::RuntimeType>::Abi, }
-            }
-            Self::Enum(name) => {
-                let name = name.to_tokens(calling_namespace);
-                quote! { <#name as ::winrt::RuntimeType>::Abi, }
-            }
-            Self::Struct(name) => {
-                let name = name.to_tokens(calling_namespace);
-                quote! { #name, }
-            }
-            Self::Delegate(_) => quote! { ::winrt::RawPtr, },
             Self::Generic(name) => {
                 let name = format_ident(name);
+                quote! { <#name as ::winrt::RuntimeType>::Abi, }
+            }
+            Self::Class(name)
+            | Self::Interface(name)
+            | Self::Delegate(name)
+            | Self::Enum(name)
+            | Self::Struct(name) => {
+                let name = name.to_tokens(calling_namespace);
                 quote! { <#name as ::winrt::RuntimeType>::Abi, }
             }
         }

--- a/crates/winmd/src/types/type_name.rs
+++ b/crates/winmd/src/types/type_name.rs
@@ -303,6 +303,10 @@ impl TypeName {
     }
 }
 
+fn format_abi_ident(name: &str) -> proc_macro2::Ident {
+    quote::format_ident!("abi_{}", name)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/winmd/src/types/type_name.rs
+++ b/crates/winmd/src/types/type_name.rs
@@ -255,27 +255,24 @@ impl TypeName {
     // and we would simply use to_tokens and to_abi_tokens everywhere but Rust is really
     // weird in requiring `IVector<T>` in some places and `IVector::<T>` in others.
     pub fn to_definition_tokens(&self, calling_namespace: &str) -> TokenStream {
-        let namespace = to_namespace_tokens(&self.namespace, calling_namespace);
         if self.generics.is_empty() {
             let name = format_ident(&self.name);
-            quote! { #namespace#name }
+            quote! { #name }
         } else {
             let name = format_ident(&self.name[..self.name.len() - 2]);
             let generics = self.generics.iter().map(|g| g.to_tokens(calling_namespace));
-            quote! { #namespace#name<#(#generics),*> }
+            quote! { #name<#(#generics),*> }
         }
     }
 
     pub fn to_abi_definition_tokens(&self, calling_namespace: &str) -> TokenStream {
-        let namespace = to_namespace_tokens(&self.namespace, calling_namespace);
-
         if self.generics.is_empty() {
             let name = format_abi_ident(&self.name);
-            quote! { #namespace#name }
+            quote! { #name }
         } else {
             let name = format_abi_ident(&self.name[..self.name.len() - 2]);
             let generics = self.generics.iter().map(|g| g.to_tokens(calling_namespace));
-            quote! { #namespace#name<#(#generics),*> }
+            quote! { #name<#(#generics),*> }
         }
     }
 

--- a/src/agile_object.rs
+++ b/src/agile_object.rs
@@ -1,0 +1,25 @@
+use crate::*;
+
+#[repr(transparent)]
+#[derive(Default, Clone)]
+pub struct IAgileObject {
+    ptr: ComPtr<IAgileObject>,
+}
+
+unsafe impl ComInterface for IAgileObject {
+    type VTable = abi_IAgileObject;
+    const IID: Guid = Guid::from_values(
+        0x94EA2B94,
+        0xE9CC,
+        0x49E0,
+        [0xC0, 0xFF, 0xEE, 0x64, 0xCA, 0x8F, 0x5B, 0x90],
+    );
+}
+
+#[repr(C)]
+pub struct abi_IAgileObject {
+    pub unknown_query_interface:
+        extern "system" fn(RawComPtr<IUnknown>, &Guid, *mut RawPtr) -> ErrorCode,
+    pub unknown_add_ref: extern "system" fn(RawComPtr<IUnknown>) -> u32,
+    pub unknown_release: extern "system" fn(RawComPtr<IUnknown>) -> u32,
+}

--- a/src/com_ptr.rs
+++ b/src/com_ptr.rs
@@ -7,6 +7,10 @@ pub struct ComPtr<T: ComInterface> {
 }
 
 impl<T: ComInterface> ComPtr<T> {
+    pub fn abi(&self) -> RawComPtr<T> {
+        self.ptr
+    }
+
     pub fn set_abi(&mut self) -> *mut RawComPtr<T> {
         if !self.ptr.is_null() {
             unsafe {

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,6 +4,17 @@
 #[must_use]
 pub type Result<T> = std::result::Result<T, Error>;
 
+impl<T> std::convert::From<Result<T>> for ErrorCode {
+    fn from(result: Result<T>) -> Self {
+        if let Err(error) = result {
+            // TODO: call SetErrorInfo
+            return error.code();
+        }
+
+        ErrorCode(0)
+    }
+}
+
 /// A WinRT related error
 #[derive(Debug)]
 pub struct Error {

--- a/src/hstring.rs
+++ b/src/hstring.rs
@@ -230,7 +230,7 @@ impl Header {
     fn duplicate(&mut self) -> *mut Header {
         if self.flags & REFERENCE_FLAG == 0 {
             unsafe {
-                (*self.shared.as_ptr()).count.addref();
+                (*self.shared.as_ptr()).count.add_ref();
                 self
             }
         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,7 @@
 
 #[doc(hidden)]
 pub mod activation;
+pub mod agile_object;
 mod array;
 mod com_interface;
 mod com_ptr;
@@ -55,6 +56,7 @@ mod unknown;
 
 #[doc(inline)]
 pub use activation::IActivationFactory;
+pub use agile_object::IAgileObject;
 pub use array::Array;
 pub use com_interface::{ComInterface, RawComPtr};
 pub use com_ptr::ComPtr;
@@ -63,12 +65,12 @@ pub use guid::Guid;
 pub use hstring::HString;
 pub use object::Object;
 pub use param::Param;
+pub use ref_count::RefCount;
 pub use runtime_name::RuntimeName;
 pub use runtime_type::RuntimeType;
 pub use try_into::TryInto;
 pub use unknown::IUnknown;
 pub use winrt_macros::import;
-pub use ref_count::RefCount;
 
 /// A convenient alias of a void pointer
 pub type RawPtr = *mut std::ffi::c_void;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,7 @@ pub use runtime_type::RuntimeType;
 pub use try_into::TryInto;
 pub use unknown::IUnknown;
 pub use winrt_macros::import;
+pub use ref_count::RefCount;
 
 /// A convenient alias of a void pointer
 pub type RawPtr = *mut std::ffi::c_void;

--- a/src/object.rs
+++ b/src/object.rs
@@ -47,7 +47,14 @@ unsafe impl RuntimeType for Object {
 
 #[repr(C)]
 pub struct abi_IInspectable {
-    __base: [usize; 4],
-    inspectable_type_name:
+    pub unknown_query_interface:
+        extern "system" fn(RawComPtr<IUnknown>, &Guid, *mut RawPtr) -> ErrorCode,
+    pub unknown_add_ref: extern "system" fn(RawComPtr<IUnknown>) -> u32,
+    pub unknown_release: extern "system" fn(RawComPtr<IUnknown>) -> u32,
+
+    pub inspectable_iids:
+        extern "system" fn(RawComPtr<Object>, *mut u32, *mut *mut Guid) -> ErrorCode,
+    pub inspectable_type_name:
         extern "system" fn(RawComPtr<Object>, *mut <HString as RuntimeType>::Abi) -> ErrorCode,
+    pub inspectable_trust_level: extern "system" fn(RawComPtr<Object>, *mut i32) -> ErrorCode,
 }

--- a/src/ref_count.rs
+++ b/src/ref_count.rs
@@ -12,7 +12,7 @@ impl RefCount {
         }
     }
 
-    pub fn addref(&self) -> u32 {
+    pub fn add_ref(&self) -> u32 {
         self.value.fetch_add(1, Ordering::Relaxed) + 1
     }
 

--- a/src/runtime_type.rs
+++ b/src/runtime_type.rs
@@ -38,4 +38,4 @@ macro_rules! primitive_runtime_type {
     };
 }
 
-primitive_runtime_type! { bool, i8, u8, i16, u16, i32, u32, i64, u64, f32, f64 } // TODO: add Guid here
+primitive_runtime_type! { bool, i8, u8, i16, u16, i32, u32, i64, u64, f32, f64 }

--- a/src/runtime_type.rs
+++ b/src/runtime_type.rs
@@ -14,6 +14,14 @@ pub unsafe trait RuntimeType {
 
     fn abi(&self) -> Self::Abi;
     fn set_abi(&mut self) -> *mut Self::Abi;
+
+    fn from_abi(abi: &Self::Abi) -> &Self {
+        unsafe { std::mem::transmute_copy(&abi) }
+    }
+
+    fn from_mut_abi(abi: &mut Self::Abi) -> &mut Self {
+        unsafe { std::mem::transmute_copy(&abi) }
+    }
 }
 
 macro_rules! primitive_runtime_type {
@@ -30,4 +38,4 @@ macro_rules! primitive_runtime_type {
     };
 }
 
-primitive_runtime_type! { bool, i8, u8, i16, u16, i32, u32, i64, u64, f32, f64 }
+primitive_runtime_type! { bool, i8, u8, i16, u16, i32, u32, i64, u64, f32, f64 } // TODO: add Guid here

--- a/src/unknown.rs
+++ b/src/unknown.rs
@@ -25,8 +25,8 @@ unsafe impl ComInterface for IUnknown {
 
 #[repr(C)]
 pub struct abi_IUnknown {
-    pub(crate) unknown_query_interface:
+    pub unknown_query_interface:
         extern "system" fn(RawComPtr<IUnknown>, &Guid, *mut RawPtr) -> ErrorCode,
-    pub(crate) unknown_add_ref: extern "system" fn(RawComPtr<IUnknown>) -> u32,
-    pub(crate) unknown_release: extern "system" fn(RawComPtr<IUnknown>) -> u32,
+    pub unknown_add_ref: extern "system" fn(RawComPtr<IUnknown>) -> u32,
+    pub unknown_release: extern "system" fn(RawComPtr<IUnknown>) -> u32,
 }

--- a/tests/delegates.rs
+++ b/tests/delegates.rs
@@ -32,7 +32,7 @@ fn non_generic() -> winrt::Result<()> {
 
     // TODO: delegates are function objects (logically) ans we should be able
     // to call them without an explicit `invoke` method e.g. `d(args);`
-    d.invoke(IAsyncAction::default(), AsyncStatus::Completed);
+    d.invoke(IAsyncAction::default(), AsyncStatus::Completed)?;
 
     assert!(invoked);
 
@@ -55,7 +55,9 @@ fn generic() -> winrt::Result<()> {
     let d = Handler::new(|sender, port| {
         invoked = true;
         assert!(uri.as_raw() == sender.as_raw());
-        assert!(port == 80);
+
+        // TODO: ideally primitives would be passed by value
+        assert!(*port == 80);
         Ok(())
     });
 

--- a/tests/delegates.rs
+++ b/tests/delegates.rs
@@ -1,0 +1,67 @@
+winrt::import!(
+    dependencies
+        "os"
+    modules
+        "windows.foundation"
+);
+
+use winrt::ComInterface;
+
+#[test]
+fn non_generic() -> winrt::Result<()> {
+    use windows::foundation::AsyncStatus;
+    use windows::foundation::IAsyncAction;
+    type Handler = windows::foundation::AsyncActionCompletedHandler;
+
+    assert_eq!(
+        Handler::IID,
+        winrt::Guid::from("A4ED5C81-76C9-40BD-8BE6-B1D90FB20AE7")
+    );
+
+    let d = Handler::default();
+    assert!(d.is_null());
+
+    let mut invoked = false;
+
+    let d = Handler::new(|info, status| {
+        invoked = true;
+        assert!(info.is_null());
+        assert!(status == AsyncStatus::Completed);
+        Ok(())
+    });
+
+    // TODO: delegates are function objects (logically) ans we should be able
+    // to call them without an explicit `invoke` method e.g. `d(args);`
+    d.invoke(IAsyncAction::default(), AsyncStatus::Completed);
+
+    assert!(invoked);
+
+    Ok(())
+}
+
+#[test]
+fn generic() -> winrt::Result<()> {
+    use windows::foundation::Uri;
+    type Handler = windows::foundation::TypedEventHandler<Uri, i32>;
+
+    // TODO: Handler::IID is not correct for generic types
+
+    let d = Handler::default();
+    assert!(d.is_null());
+
+    let uri = &Uri::create_uri("http://kennykerr.ca")?;
+    let mut invoked = false;
+
+    let d = Handler::new(|sender, port| {
+        invoked = true;
+        assert!(uri.as_raw() == sender.as_raw());
+        assert!(port == 80);
+        Ok(())
+    });
+
+    d.invoke(uri, uri.port()?)?;
+
+    assert!(invoked);
+
+    Ok(())
+}

--- a/tests/xaml.rs
+++ b/tests/xaml.rs
@@ -1,11 +1,11 @@
-winrt::import!(
-    dependencies
-        "os"
-    modules
-        "windows.ui.xaml"
-);
+// winrt::import!(
+//     dependencies
+//         "os"
+//     modules
+//         "windows.ui.xaml"
+// );
 
-#[test]
-fn xaml() -> winrt::Result<()> {
-    Ok(())
-}
+// #[test]
+// fn xaml() -> winrt::Result<()> {
+//     Ok(())
+// }

--- a/tests/xaml.rs
+++ b/tests/xaml.rs
@@ -1,11 +1,11 @@
-// winrt::import!(
-//     dependencies
-//         "os"
-//     modules
-//         "windows.ui.xaml"
-// );
+winrt::import!(
+    dependencies
+        "os"
+    modules
+        "windows.ui.xaml"
+);
 
-// #[test]
-// fn xaml() -> winrt::Result<()> {
-//     Ok(())
-// }
+#[test]
+fn xaml() -> winrt::Result<()> {
+    Ok(())
+}


### PR DESCRIPTION
WinRT delegates are COM interfaces that behave like function objects. They are used as callbacks for some APIs but overwhelmingly used to implement events and are thus required by many Windows APIs.

Much like WinRT interfaces, delegates may be generic and non-generic and like interfaces, generic delegates require GUIDs derived from their generic arguments. This update provides basic support for delegates and while you can call a generic delegate, you cannot use it with any API that might attempt to query its GUID. That's why I need to add support for #129 to unblock full use of delegates and then a ton more Windows APIs will suddenly light up.

Delegates also give the first taste of authoring support in Rust. Full authoring support will come later #81 and includes the ability to author WinRT classes and interfaces. For now, delegates represent a very simple form of type authoring as they require the caller to provide an implementation of the delegate's underlying COM interface. The implementation details need some improvement but this will unblock me to work on some of the other prerequisites as we move toward getting more of the type system online. 

There are also a few usability issues that I still need to address. 

* Delegates whose closures don't (wish to) propagate failure should be able to avoid the trailing `Ok(())`. 
* API parameters that expect a delegate should be able to accept a closure directly rather than having the caller wrap it in `DelegateName::new(|| ...)` as that can be quite tedious. 
* I should be able to call a delegate like a function object e.g. `delegate(a, b, c)` instead of `delegate.invoke(a, b, c)`.

So room for improvement, but at least here we have the ABI roughed in so we can start building on this.

Fixes #72