### PR TITLE
Return `T` instead of `winrt::Result<T>` for `noexcept` methods

### DIFF
--- a/crates/winmd/build.rs
+++ b/crates/winmd/build.rs
@@ -1,0 +1,15 @@
+use std::process::Command;
+use std::env;
+
+fn main() {
+    let out = env::var("OUT_DIR").unwrap();
+
+    Command::new(r"C:\Windows\Microsoft.NET\Framework\v4.0.30319\ilasm.exe")
+        .args(&["/DLL"])
+        .arg(format!("/output={}/RustWinRT.Tests.winmd", out).as_str())
+        .arg("./tests/RustWinRT.Tests.il")
+        .status()
+        .unwrap();
+    
+    println!("cargo:rerun-if-changed=./tests/RustWinRT.Tests.il");
+}

--- a/crates/winmd/build.rs
+++ b/crates/winmd/build.rs
@@ -4,7 +4,7 @@ use std::env;
 fn main() {
     let out = env::var("OUT_DIR").unwrap();
 
-    Command::new(r"C:\Windows\Microsoft.NET\Framework\v4.0.30319\ilasm.exe")
+    Command::new(r"ilasm")
         .args(&["/DLL"])
         .arg(format!("/output={}/RustWinRT.Tests.winmd", out).as_str())
         .arg("./tests/RustWinRT.Tests.il")

--- a/crates/winmd/src/types/method.rs
+++ b/crates/winmd/src/types/method.rs
@@ -179,7 +179,7 @@ impl Method {
             extern "system" fn #name(this: *const *const #abi_name, #(#params)*) -> ::winrt::ErrorCode
         }
     }
-    
+
     fn to_param_tokens(&self, calling_namespace: &str) -> TokenStream {
         TokenStream::from_iter(
             self.params
@@ -296,7 +296,7 @@ impl Method {
 
     pub fn to_static_tokens(
         &self,
-        calling_namespace: &str,    
+        calling_namespace: &str,
         interface: &RequiredInterface,
     ) -> TokenStream {
         let method_name = format_ident(&self.name);
@@ -317,10 +317,9 @@ impl Method {
 
 #[cfg(test)]
 mod tests {
-    use std::env;
-    use std::path::Path;
     use super::*;
     use crate::types::*;
+    use std::path::Path;
 
     fn method((namespace, type_name): (&str, &str), method_name: &str, reader: &TypeReader) -> Method {
         let def = reader.resolve_type_def((namespace, type_name));

--- a/crates/winmd/tests/RustWinRT.Tests.il
+++ b/crates/winmd/tests/RustWinRT.Tests.il
@@ -1,0 +1,53 @@
+// This IL file represents a WinMD file similar to the following IDL:
+//
+// namespace RustWinRT.Tests
+// {
+//     interface ITestNoException
+//     {
+//         [noexcept] String NoException();
+//         String MaybeException();
+//     }
+// }
+
+.assembly extern mscorlib
+{
+    .publickeytoken = (b7 7a 5c 56 19 34 e0 89)
+    .ver 4:0:0:0
+}
+
+.assembly extern windowsruntime Windows.Foundation
+{
+    .ver 4:0:0:0
+}
+
+.assembly extern windowsruntime winrtbase
+{
+    .ver 255:255:255:255
+}
+
+.module RustWinRT.Tests.winmd
+.imagebase 0x00400000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003 // WindowsCui
+.corflags 0x00000001 // ILOnly
+
+
+.class private auto ansi '<Module>'
+{
+} // end of class <Module>
+
+.class interface public auto ansi abstract import windowsruntime RustWinRT.Tests.ITestNoException
+{
+    .custom instance void [Windows.Foundation]Windows.Foundation.Metadata.VersionAttribute::.ctor(uint32) = (01 00 01 00 00 00 00 00)
+    .custom instance void [Windows.Foundation]Windows.Foundation.Metadata.GuidAttribute::.ctor(uint32, uint16, uint16, uint8, uint8, uint8, uint8, uint8, uint8, uint8, uint8) 
+        = (01 00 56 0f 15 2e 5d 31 ca 58 84 49 d2 7d ed bb 67 6b 00 00)
+
+    .method public hidebysig newslot abstract virtual instance string NoException() runtime managed
+    {
+        .custom instance void [winrtbase]Windows.Foundation.Metadata.NoExceptionAttribute::.ctor() = (01 00 00 00)
+    }
+    .method public hidebysig newslot abstract virtual instance string MaybeException() runtime managed
+    {
+    }
+}

--- a/crates/winmd/tests/RustWinRT.Tests.il
+++ b/crates/winmd/tests/RustWinRT.Tests.il
@@ -1,4 +1,5 @@
-// This IL file represents a WinMD file similar to the following IDL:
+// Since the MIDL toolchain is Windows-only, this WinMD file is written in IL.
+// The WinMD generated from this IL is similar to what the following MIDL expresses:
 //
 // namespace RustWinRT.Tests
 // {
@@ -8,6 +9,9 @@
 //         String MaybeException();
 //     }
 // }
+//
+// Since there are currently no APIs in the Windows SDK that use noexcept,
+// this IL is needed to test that functionality.
 
 .assembly extern mscorlib
 {


### PR DESCRIPTION
Methods with the `noexcept` attribute should not return errors. This PR allows methods marked as such to return just `T` instead of `winrt::Result<T>`.

Unfortunately, I don't know of a good way to test this end-to-end, since there are no APIs in the Windows SDK that make use of `noexcept` at the moment. Currently, this PR builds its own testing WinMD from IL, which is used to test that the metadata parsing logic works correctly. However, nothing is testing whether the actually generated code is correct (or even compiles). I can take a look into testing this 'manually' with a one-off library in a couple of days.

Additionally, I don't know a good way to invoke `ilasm` in the build.rs (I just pasted in the full path when testing), so I would appreciate a good way to do that. The tests pass otherwise.

I do not know too much about Rust, and this is my first time doing anything serious with it. Please go easy on me 😄 