### PR TITLE
Add basic build crate for build.rs support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/microsoft/winrt-rs"
 
 [dependencies]
 winrt_macros = { path = "crates/macros" }
+winrt-build = { path = "crates/winrt-build" }
 sha1 = "0.6.0"
 
 [dev-dependencies]

--- a/crates/macros/Cargo.toml
+++ b/crates/macros/Cargo.toml
@@ -11,5 +11,4 @@ proc-macro = true
 syn = "1.0"
 quote = "1.0"
 proc-macro2 = "1.0"
-serde_json = "1.0"
 winmd = { path = "../winmd" }

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -1,10 +1,10 @@
 extern crate proc_macro;
 
 use proc_macro::{TokenStream, TokenTree};
-use winmd::{TypeLimits, TypeReader, TypeStage};
+use winmd::{dependencies, TypeLimits, TypeReader, TypeStage};
 
 use std::collections::BTreeSet;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 /// A macro for generating WinRT modules into the current module
 #[proc_macro]
@@ -152,7 +152,7 @@ fn parse_dependencies(
         let token = stream.peek();
         match token {
             Some(TokenTree::Literal(value)) => {
-                expand_paths(
+                dependencies::expand_paths(
                     value.to_string().trim_matches('"'),
                     &mut dependencies,
                     false,
@@ -166,7 +166,7 @@ fn parse_dependencies(
                 path.push(wind_dir_env);
                 path.push(SYSTEM32);
                 path.push("winmetadata");
-                expand_paths(path, &mut dependencies, false);
+                dependencies::expand_paths(path, &mut dependencies, false);
                 let _os = stream.next();
             }
             Some(TokenTree::Ident(value)) if value.to_string().as_str() == "nuget" => {
@@ -179,10 +179,7 @@ fn parse_dependencies(
                     },
                     "`nuget` must be followed by a `:`"
                 );
-                let mut path = workspace_root();
-
-                path.push("target");
-                path.push("nuget");
+                let mut path = winmd::dependencies::nuget_root();
 
                 let mut name = String::new();
                 while {
@@ -201,54 +198,12 @@ fn parse_dependencies(
                 }
                 path.push(name);
 
-                expand_paths(path, &mut dependencies, true);
+                dependencies::expand_paths(path, &mut dependencies, true);
             }
             _ => break,
         }
     }
     dependencies
-}
-
-/// Returns the paths to resolved dependencies
-fn expand_paths<P: AsRef<Path>>(dependency: P, result: &mut BTreeSet<PathBuf>, recurse: bool) {
-    let path = dependency.as_ref();
-
-    if path.is_dir() {
-        let paths = std::fs::read_dir(path).unwrap_or_else(|e| {
-            panic!(
-                "Could not read dependecy directory at path {:?}: {}",
-                path, e
-            )
-        });
-        for path in paths {
-            let path = path.expect("Could not read directory entry");
-            let path = path.path();
-            if path.is_file() && path.extension() == Some(std::ffi::OsStr::new("winmd")) {
-                result.insert(path);
-            } else if path.is_dir() && recurse {
-                expand_paths(path, result, recurse)
-            }
-        }
-    } else if path.is_file() && path.extension() == Some(std::ffi::OsStr::new("winmd")) {
-        result.insert(path.to_path_buf());
-    } else {
-        panic!("Dependency {} is not a file or directory", path.display());
-    }
-}
-
-fn workspace_root() -> PathBuf {
-    let output = std::process::Command::new("cargo")
-        .args(&["metadata"])
-        .output()
-        .expect("Could not run `cargo metadata`")
-        .stdout;
-    let value: serde_json::Map<String, serde_json::Value> =
-        serde_json::from_slice(&output).expect("`cargo metadata` did not return json.");
-    let path = match value.get("workspace_root") {
-        Some(serde_json::Value::String(s)) => s,
-        _ => panic!("`cargo metadata` json was not in expected format"),
-    };
-    PathBuf::from(path)
 }
 
 // Snake <-> camel casing is lossy so we go for character but not case conversion

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -160,12 +160,7 @@ fn parse_dependencies(
                 let _literal = stream.next();
             }
             Some(TokenTree::Ident(value)) if value.to_string().as_str() == "os" => {
-                let mut path = PathBuf::new();
-                let wind_dir_env = std::env::var("windir")
-                    .unwrap_or_else(|_| panic!("No `windir` environment variable found"));
-                path.push(wind_dir_env);
-                path.push(SYSTEM32);
-                path.push("winmetadata");
+                let path = winmd::dependencies::system_metadata_root();
                 dependencies::expand_paths(path, &mut dependencies, false);
                 let _os = stream.next();
             }
@@ -217,9 +212,3 @@ fn namespace_literal_to_rough_namespace(namespace: &str) -> String {
     }
     result
 }
-
-#[cfg(target_pointer_width = "64")]
-const SYSTEM32: &str = "System32";
-
-#[cfg(target_pointer_width = "32")]
-const SYSTEM32: &str = "SysNative";

--- a/crates/winmd/Cargo.toml
+++ b/crates/winmd/Cargo.toml
@@ -9,3 +9,4 @@ winmd_macros = { path = "macros" }
 quote = "1.0"
 proc-macro2 = "1.0"
 sha1 = "0.6.0"
+serde_json = "1.0"

--- a/crates/winmd/src/dependencies.rs
+++ b/crates/winmd/src/dependencies.rs
@@ -1,0 +1,52 @@
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+/// Returns the paths to resolved dependencies
+pub fn expand_paths<P: AsRef<Path>>(dependency: P, result: &mut BTreeSet<PathBuf>, recurse: bool) {
+    let path = dependency.as_ref();
+
+    if path.is_dir() {
+        let paths = std::fs::read_dir(path).unwrap_or_else(|e| {
+            panic!(
+                "Could not read dependecy directory at path {:?}: {}",
+                path, e
+            )
+        });
+        for path in paths {
+            let path = path.expect("Could not read directory entry");
+            let path = path.path();
+            if path.is_file() && path.extension() == Some(std::ffi::OsStr::new("winmd")) {
+                result.insert(path);
+            } else if path.is_dir() && recurse {
+                expand_paths(path, result, recurse)
+            }
+        }
+    } else if path.is_file() && path.extension() == Some(std::ffi::OsStr::new("winmd")) {
+        result.insert(path.to_path_buf());
+    } else {
+        panic!("Dependency {} is not a file or directory", path.display());
+    }
+}
+
+pub fn nuget_root() -> PathBuf {
+    let mut path = workspace_root();
+
+    path.push("target");
+    path.push("nuget");
+    path
+}
+
+fn workspace_root() -> PathBuf {
+    let output = std::process::Command::new("cargo")
+        .args(&["metadata"])
+        .output()
+        .expect("Could not run `cargo metadata`")
+        .stdout;
+    let value: serde_json::Map<String, serde_json::Value> =
+        serde_json::from_slice(&output).expect("`cargo metadata` did not return json.");
+    let path = match value.get("workspace_root") {
+        Some(serde_json::Value::String(s)) => s,
+        _ => panic!("`cargo metadata` json was not in expected format"),
+    };
+    PathBuf::from(path)
+}

--- a/crates/winmd/src/dependencies.rs
+++ b/crates/winmd/src/dependencies.rs
@@ -30,9 +30,19 @@ pub fn expand_paths<P: AsRef<Path>>(dependency: P, result: &mut BTreeSet<PathBuf
 
 pub fn nuget_root() -> PathBuf {
     let mut path = workspace_root();
-
     path.push("target");
     path.push("nuget");
+    path
+}
+
+pub fn system_metadata_root() -> PathBuf {
+    let mut path = PathBuf::new();
+    let wind_dir_env = std::env::var("windir")
+        .unwrap_or_else(|_| panic!("No `windir` environment variable found"));
+    path.push(wind_dir_env);
+    path.push(SYSTEM32);
+    path.push("winmetadata");
+
     path
 }
 
@@ -50,3 +60,9 @@ fn workspace_root() -> PathBuf {
     };
     PathBuf::from(path)
 }
+
+#[cfg(target_pointer_width = "64")]
+const SYSTEM32: &str = "System32";
+
+#[cfg(target_pointer_width = "32")]
+const SYSTEM32: &str = "SysNative";

--- a/crates/winmd/src/lib.rs
+++ b/crates/winmd/src/lib.rs
@@ -1,6 +1,7 @@
 mod blob;
 mod case;
 mod codes;
+
 mod file;
 mod flags;
 mod row;
@@ -12,6 +13,7 @@ mod type_stage;
 mod type_tree;
 mod types;
 
+pub mod dependencies;
 pub mod load_winmd;
 pub use file::WinmdFile;
 pub use type_limits::TypeLimits;

--- a/crates/winrt-build/Cargo.toml
+++ b/crates/winrt-build/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "winrt-build"
+version = "0.1.0"
+authors = ["Ryan Levick <ryan.levick@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+winmd = { path = "../winmd" }

--- a/crates/winrt-build/Cargo.toml
+++ b/crates/winrt-build/Cargo.toml
@@ -1,10 +1,8 @@
 [package]
 name = "winrt-build"
 version = "0.1.0"
-authors = ["Ryan Levick <ryan.levick@gmail.com>"]
+authors = ["Microsoft"]
 edition = "2018"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 winmd = { path = "../winmd" }

--- a/crates/winrt-build/src/lib.rs
+++ b/crates/winrt-build/src/lib.rs
@@ -78,6 +78,9 @@ impl Builder {
             // workaround for, well, overflowing literals
             // writeln!(&mut stdin, "#![allow(overflowing_literals)]")?;
 
+            // Only rerun if the
+            println!("cargo:rerun-if-env-changed={}", self.output.display());
+
             let tokens = tt.to_tokens();
 
             writeln!(&mut stdin, "{}", tokens)?;

--- a/crates/winrt-build/src/lib.rs
+++ b/crates/winrt-build/src/lib.rs
@@ -1,51 +1,90 @@
-use std::{fs, io::Write, path::Path, process::Stdio};
+use std::{
+    env, fs,
+    io::Write,
+    path::{Path, PathBuf},
+    process::Stdio,
+};
 
-pub fn build<P: AsRef<Path>>(
-    namespaces: &[&str],
-    output: P,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let output = output.as_ref();
-    let tr = winmd::TypeReader::from_os();
+pub struct Builder {
+    namespaces: Vec<String>,
+    output: PathBuf,
+    dependencies: Dependencies,
+}
 
-    let mut tl: winmd::TypeLimits = Default::default();
-    for ns in namespaces {
-        tl.insert(&tr, ns);
+pub enum Dependencies {
+    Os,
+    Nuget(Vec<String>),
+    OsAndNuget(Vec<String>),
+}
+
+impl Default for Builder {
+    fn default() -> Self {
+        Self {
+            dependencies: Dependencies::Os,
+            namespaces: Vec::new(),
+            output: PathBuf::from(env::var("OUT_DIR").expect("No `OUT_DIR` env variable set"))
+                .join("bindings.rs"),
+        }
+    }
+}
+
+impl Builder {
+    pub fn insert_namespaces<T: Iterator<Item = String>>(mut self, namespaces: T) -> Self {
+        self.namespaces.extend(namespaces);
+        self
     }
 
-    let ts = winmd::TypeStage::from_limits(&tr, &tl);
-    let tt = ts.into_tree();
-
-    fs::create_dir_all(output.parent().unwrap())?;
-    let mut f = fs::File::create(output)?;
-
-    let mut cmd = std::process::Command::new("rustfmt");
-    cmd.arg("--emit").arg("stdout");
-    cmd.stdin(Stdio::piped());
-    cmd.stdout(Stdio::piped());
-    {
-        let child = cmd.spawn()?;
-        let mut stdin = child.stdin.unwrap();
-        let stdout = child.stdout.unwrap();
-
-        let t = std::thread::spawn(move || {
-            let mut s = stdout;
-            std::io::copy(&mut s, &mut f).unwrap();
-        });
-
-        // workaround for, well, overflowing literals
-        writeln!(&mut stdin, "#![allow(overflowing_literals)]").unwrap();
-
-        let tokens = tt.to_tokens();
-
-        writeln!(&mut stdin, "{}", tokens).unwrap();
-        // drop stdin to close that end of the pipe
-        drop(stdin);
-
-        t.join().unwrap();
+    pub fn output<P: AsRef<Path>>(mut self, path: P) -> Self {
+        self.output = path.as_ref().to_owned();
+        self
     }
 
-    let status = cmd.status()?;
-    assert!(status.success());
+    pub fn build(&self) -> Result<(), Box<dyn std::error::Error>> {
+        let tr = match self.dependencies {
+            Dependencies::Os => winmd::TypeReader::from_os(),
+            _ => todo!(),
+        };
 
-    Ok(())
+        let mut tl = winmd::TypeLimits::default();
+        for ns in &self.namespaces {
+            tl.insert(&tr, &ns);
+        }
+
+        let ts = winmd::TypeStage::from_limits(&tr, &tl);
+        let tt = ts.into_tree();
+
+        fs::create_dir_all(self.output.parent().unwrap())?;
+        let mut f = fs::File::create(&self.output)?;
+
+        let mut cmd = std::process::Command::new("rustfmt");
+        cmd.arg("--emit").arg("stdout");
+        cmd.stdin(Stdio::piped());
+        cmd.stdout(Stdio::piped());
+        {
+            let child = cmd.spawn()?;
+            let mut stdin = child.stdin.unwrap();
+            let stdout = child.stdout.unwrap();
+
+            let t = std::thread::spawn(move || {
+                let mut s = stdout;
+                std::io::copy(&mut s, &mut f).unwrap();
+            });
+
+            // workaround for, well, overflowing literals
+            writeln!(&mut stdin, "#![allow(overflowing_literals)]")?;
+
+            let tokens = tt.to_tokens();
+
+            writeln!(&mut stdin, "{}", tokens)?;
+            // drop stdin to close that end of the pipe
+            drop(stdin);
+
+            t.join().unwrap();
+        }
+
+        let status = cmd.status()?;
+        assert!(status.success());
+
+        Ok(())
+    }
 }

--- a/crates/winrt-build/src/lib.rs
+++ b/crates/winrt-build/src/lib.rs
@@ -114,10 +114,7 @@ impl Builder {
                 std::io::copy(&mut s, &mut f).unwrap();
             });
 
-            // workaround for, well, overflowing literals
-            // writeln!(&mut stdin, "#![allow(overflowing_literals)]")?;
-
-            // Only rerun if the
+            // Only rerun if the output file has changed
             println!("cargo:rerun-if-env-changed={}", self.output.display());
 
             let tokens = tt.to_tokens();

--- a/crates/winrt-build/src/lib.rs
+++ b/crates/winrt-build/src/lib.rs
@@ -29,8 +29,13 @@ impl Default for Builder {
 }
 
 impl Builder {
-    pub fn insert_namespaces<T: Iterator<Item = String>>(mut self, namespaces: T) -> Self {
-        self.namespaces.extend(namespaces);
+    pub fn insert_namespaces<T>(mut self, namespaces: T) -> Self
+    where
+        T: IntoIterator,
+        T::Item: std::string::ToString,
+    {
+        self.namespaces
+            .extend(namespaces.into_iter().map(|s| s.to_string()));
         self
     }
 
@@ -71,7 +76,7 @@ impl Builder {
             });
 
             // workaround for, well, overflowing literals
-            writeln!(&mut stdin, "#![allow(overflowing_literals)]")?;
+            // writeln!(&mut stdin, "#![allow(overflowing_literals)]")?;
 
             let tokens = tt.to_tokens();
 

--- a/crates/winrt-build/src/lib.rs
+++ b/crates/winrt-build/src/lib.rs
@@ -1,0 +1,51 @@
+use std::{fs, io::Write, path::Path, process::Stdio};
+
+pub fn build<P: AsRef<Path>>(
+    namespaces: &[&str],
+    output: P,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let output = output.as_ref();
+    let tr = winmd::TypeReader::from_os();
+
+    let mut tl: winmd::TypeLimits = Default::default();
+    for ns in namespaces {
+        tl.insert(&tr, ns);
+    }
+
+    let ts = winmd::TypeStage::from_limits(&tr, &tl);
+    let tt = ts.into_tree();
+
+    fs::create_dir_all(output.parent().unwrap())?;
+    let mut f = fs::File::create(output)?;
+
+    let mut cmd = std::process::Command::new("rustfmt");
+    cmd.arg("--emit").arg("stdout");
+    cmd.stdin(Stdio::piped());
+    cmd.stdout(Stdio::piped());
+    {
+        let child = cmd.spawn()?;
+        let mut stdin = child.stdin.unwrap();
+        let stdout = child.stdout.unwrap();
+
+        let t = std::thread::spawn(move || {
+            let mut s = stdout;
+            std::io::copy(&mut s, &mut f).unwrap();
+        });
+
+        // workaround for, well, overflowing literals
+        writeln!(&mut stdin, "#![allow(overflowing_literals)]").unwrap();
+
+        let tokens = tt.to_tokens();
+
+        writeln!(&mut stdin, "{}", tokens).unwrap();
+        // drop stdin to close that end of the pipe
+        drop(stdin);
+
+        t.join().unwrap();
+    }
+
+    let status = cmd.status()?;
+    assert!(status.success());
+
+    Ok(())
+}

--- a/examples/nuget-dependency/Cargo.toml
+++ b/examples/nuget-dependency/Cargo.toml
@@ -7,4 +7,7 @@ edition = "2018"
 [dependencies]
 winrt = { path = "../.." }
 
+[build-dependencies]
+winrt = { path = "../.." }
+
 [workspace]

--- a/examples/nuget-dependency/Cargo.toml
+++ b/examples/nuget-dependency/Cargo.toml
@@ -10,4 +10,7 @@ winrt = { path = "../.." }
 [build-dependencies]
 winrt = { path = "../.." }
 
+[package.metadata.nuget_dependencies]
+"Microsoft.Windows.SDK.Contracts" = "1.25.0"
+
 [workspace]

--- a/examples/nuget-dependency/README.md
+++ b/examples/nuget-dependency/README.md
@@ -1,7 +1,15 @@
 # Nuget Dependency File
 
-This is an example of a project with a dependency on a nuget package. Nuget based 
-winmd files are expected to be found in `$project_root\target\nuget\$name_of_package`.
+This is an example of a project with a dependency on a nuget package.
+
+## Installation
+
+To install the NuGet based dependency use [`cargo nuget`](https://github.com/rylev/cargo-nuget).
+
+```
+cargo install --git https://github.com/rylev/cargo-nuget
+cargo nuget install
+```
 
 ## Running the example
 

--- a/examples/nuget-dependency/build.rs
+++ b/examples/nuget-dependency/build.rs
@@ -3,6 +3,7 @@ use winrt::Builder;
 fn main() {
     Builder::default()
         .insert_namespaces(&["windows.foundation"])
+        .insert_nuget(&["Microsoft.Windows.SDK.Contracts"])
         .build()
         .unwrap();
 }

--- a/examples/nuget-dependency/build.rs
+++ b/examples/nuget-dependency/build.rs
@@ -1,8 +1,8 @@
+use winrt::Builder;
+
 fn main() {
-    let current = std::env::current_dir().unwrap();
-    let src = current.join("nuget");
-    let target = current.join("target").join("nuget");
-    if !target.exists() {
-        std::os::windows::fs::symlink_dir(src, target).unwrap();
-    }
+    Builder::default()
+        .insert_namespaces(&["windows.foundation"])
+        .build()
+        .unwrap();
 }

--- a/examples/nuget-dependency/src/main.rs
+++ b/examples/nuget-dependency/src/main.rs
@@ -1,9 +1,7 @@
-winrt::import!(
-    dependencies
-        nuget: Microsoft.Windows.SDK.Contracts
-    modules
-        "windows.foundation"
-);
+#![allow(overflowing_literals)]
+
+include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+
 use windows::foundation::PropertyValue;
 
 fn main() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,6 +75,7 @@ pub use runtime_name::RuntimeName;
 pub use runtime_type::RuntimeType;
 pub use try_into::TryInto;
 pub use unknown::IUnknown;
+pub use winrt_build::Builder;
 pub use winrt_macros::import;
 
 /// A convenient alias of a void pointer


### PR DESCRIPTION
This is based on @fasterthanlime's work. I'd like to get their approval first. I can also add @fasterthanlime as an author. 

In a build.rs script for your project you can run:

**EDIT: THIS HAS CHANGED. SEE BELOW**
```rust
fn main() {
    winrt_build::build(&["windows.foundation"], "./src/bindings.rs").unwrap()
}
```

And then use them in:

```rust
mod bindings;
use bindings::windows;
```