### PR TITLE
Fix stack overflow in From<HString> for String impl

### DIFF
--- a/src/hstring.rs
+++ b/src/hstring.rs
@@ -188,7 +188,7 @@ impl<'a> From<&'a HString> for String {
 
 impl From<HString> for String {
     fn from(hstring: HString) -> Self {
-        hstring.into()
+        String::from(&hstring)
     }
 }
 
@@ -316,5 +316,12 @@ mod tests {
     fn from_empty_string() {
         let h = HString::from("");
         assert!(format!("{}", h) == "");
+    }
+
+    #[test]
+    fn hstring_to_string() {
+        let h = HString::from("test");
+        let s = String::from(h);
+        assert!(s == "test");
     }
 }


### PR DESCRIPTION
The current impl does an infinite recursion into itself, eventually leading to a stack overflow. I suppose the implementation was supposed to call the `impl From<&HString> for String` defined above.