### PR TITLE
Fixed typo in comment

### DIFF
--- a/src/hstring.rs
+++ b/src/hstring.rs
@@ -5,7 +5,7 @@ use std::ptr;
 
 /// A handle to a [Windows Runtime string](https://docs.microsoft.com/en-us/windows/win32/winrt/hstring)
 ///
-/// This handle should only be used for FFI purposes with Window Runtime APIs.
+/// This handle should only be used for FFI purposes with Windows Runtime APIs.
 #[repr(transparent)]
 pub struct HString {
     ptr: *mut Header,


### PR DESCRIPTION
Replaced *Window Runtime* with *Windows Runtime* in a comment. With this being a Rust doc comment it is eventually/potentially a public facing artifact.