### PR TITLE
Remove automatic parent inclusion

### DIFF
--- a/crates/winmd/src/type_limits.rs
+++ b/crates/winmd/src/type_limits.rs
@@ -15,54 +15,6 @@ impl TypeLimits {
             .find(|name| name.to_lowercase() == namespace)
             .unwrap_or_else(|| panic!("Namespace `{}` not found in winmd files", namespace));
 
-        let mut namespace = found.as_str();
-        self.0.insert(namespace.to_owned());
-
-        while let Some(pos) = namespace.rfind('.') {
-            namespace = &namespace[..pos];
-
-            if reader.types.contains_key(namespace) {
-                self.0.insert(namespace.to_owned());
-            }
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_parent_inclusion() {
-        let reader = &TypeReader::from_os();
-
-        {
-            // Windows.Foundation's parent is empty so that's not included
-            let mut limits = TypeLimits::default();
-            limits.insert(reader, "windows.foundation");
-            assert!(limits.0.len() == 1);
-            assert!(limits.0.contains("Windows.Foundation"));
-        }
-
-        {
-            // Windows.Foundation.Collections's parent is not empty so it gets included
-            let mut limits = TypeLimits::default();
-            limits.insert(reader, "windows.foundation.collections");
-            assert!(limits.0.len() == 2);
-            assert!(limits.0.contains("Windows.Foundation"));
-            assert!(limits.0.contains("Windows.Foundation.Collections"));
-        }
-
-        {
-            let mut limits = TypeLimits::default();
-            limits.insert(reader, "windows.foundation.collections");
-            limits.insert(reader, "windows.ui.xaml.controls");
-            assert!(limits.0.len() == 5);
-            assert!(limits.0.contains("Windows.Foundation"));
-            assert!(limits.0.contains("Windows.Foundation.Collections"));
-            assert!(limits.0.contains("Windows.UI"));
-            assert!(limits.0.contains("Windows.UI.Xaml"));
-            assert!(limits.0.contains("Windows.UI.Xaml.Controls"));
-        }
+        self.0.insert(found.to_owned());
     }
 }

--- a/tests/collections.rs
+++ b/tests/collections.rs
@@ -2,6 +2,7 @@ winrt::import!(
     dependencies
         os
     modules
+        "windows.foundation"
         "windows.foundation.collections"
 );
 

--- a/tests/composition.rs
+++ b/tests/composition.rs
@@ -2,6 +2,7 @@ winrt::import!(
     dependencies
         os
     modules
+        "windows.ui"
         "windows.ui.composition"
 );
 

--- a/tests/delegates.rs
+++ b/tests/delegates.rs
@@ -2,6 +2,7 @@ winrt::import!(
     dependencies
         os
     modules
+        "windows.foundation"
         "windows.foundation.collections"
 );
 

--- a/tests/generic_guids.rs
+++ b/tests/generic_guids.rs
@@ -2,6 +2,7 @@ winrt::import!(
     dependencies
         os
     modules
+        "windows.foundation"
         "windows.foundation.collections"
         "windows.foundation.numerics"
 );

--- a/tests/interface.rs
+++ b/tests/interface.rs
@@ -2,6 +2,7 @@ winrt::import!(
     dependencies
         os
     modules
+        "windows.foundation"
         "windows.foundation.collections"
 );
 

--- a/tests/uri.rs
+++ b/tests/uri.rs
@@ -2,6 +2,7 @@ winrt::import!(
     dependencies
         os
     modules
+        "windows.foundation"
         "windows.foundation.collections"
 );
 


### PR DESCRIPTION
This substantially reduces the amount of generated code for large namespaces like Windows.UI.Xaml.* and paves the way for #119.