### PR TITLE
Moving to use non-null pointers

### DIFF
--- a/src/activation_factory.rs
+++ b/src/activation_factory.rs
@@ -9,14 +9,18 @@ pub struct IActivationFactory {
 
 impl IActivationFactory {
     pub fn activate_instance<I: ComInterface>(&self) -> Result<I> {
-        if self.ptr.is_null() {
-            panic!("The `this` pointer was null when calling method");
-        }
-
-        let mut object = Object::default();
-        unsafe {
-            ((*(*(self.ptr.as_raw()))).activate_instance)(self.ptr.as_raw(), object.set_abi())
-                .and_then(|| object.query())
+        match self.ptr.as_raw() {
+            None => panic!("The `this` pointer was null when calling method"),
+            Some(ptr) => {
+                let mut object = Object::default();
+                unsafe {
+                    ((*(*ptr.as_ptr()).as_ptr()).activate_instance)(
+                        self.ptr.as_raw(),
+                        object.set_abi(),
+                    )
+                    .and_then(|| object.query())
+                }
+            }
         }
     }
 }

--- a/src/com_interface.rs
+++ b/src/com_interface.rs
@@ -19,20 +19,33 @@ pub unsafe trait ComInterface: Sized {
     // TODO: this should be a const function returning &'static Guid
     fn iid() -> Guid;
 
+    /// Turn a `ComInterface` into a `RawComPtr`
+    ///
+    /// Note: `RawComPtr`s do not perform an IUnknown reference counting.
+    /// Therefore it is important to only hold on to the returned `RawComPtr`
+    /// for at most the lifetime of `&self`
     #[inline(always)]
     fn as_raw(&self) -> RawComPtr<Self> {
+        // Safe because ComInterface's are by definition `RawComPtr`s
         unsafe { std::mem::transmute_copy(self) }
     }
 
+    /// Get the `ComInterface` as a `RawComPtr<IUnknown>`
+    ///
+    /// Note: `RawComPtr`s do not perform an IUnknown reference counting.
+    /// Therefore it is important to only hold on to the returned `RawComPtr`
+    /// for at most the lifetime of `&self`
     #[inline(always)]
     fn as_iunknown(&self) -> RawComPtr<IUnknown> {
-        self.as_raw() as _
+        self.as_raw().map(|s| s.cast())
     }
 
     #[inline(always)]
     fn query<Into: ComInterface>(&self) -> Into {
         unsafe {
+            // Safe because `ComInterfaces` by definition must be safe to zero intialize
             let mut into: Into = std::mem::zeroed();
+            // Safe because the supplied `IID` is the `IID` of the supplied queried type
             self.raw_query(&Into::iid(), &mut into);
             into
         }
@@ -40,16 +53,20 @@ pub unsafe trait ComInterface: Sized {
 
     #[inline(always)]
     fn is_null(&self) -> bool {
-        self.as_raw().is_null()
+        self.as_raw().is_none()
     }
 
     unsafe fn raw_query<T: ComInterface>(&self, guid: &Guid, ppv: &mut T) {
         let from = self.as_iunknown();
-        if !from.is_null() {
-            ((*(*(from))).unknown_query_interface)(from, guid, ppv as *mut _ as _);
+        if let Some(from) = from {
+            ((*(*from.as_ptr()).as_ptr()).unknown_query_interface)(
+                Some(from),
+                guid,
+                ppv as *mut _ as _,
+            );
         }
     }
 }
 
 /// A non-reference-counted pointer to a COM interface
-pub type RawComPtr<T> = *const *const <T as ComInterface>::VTable;
+pub type RawComPtr<T> = Option<std::ptr::NonNull<std::ptr::NonNull<<T as ComInterface>::VTable>>>;

--- a/src/object.rs
+++ b/src/object.rs
@@ -11,15 +11,20 @@ pub struct Object {
 
 impl Object {
     pub fn type_name(&self) -> Result<HString> {
-        let this = self.ptr.as_raw();
-        if this.is_null() {
-            panic!("The `this` pointer was null when calling method");
+        match self.ptr.as_raw() {
+            None => panic!("The `this` pointer was null when calling method"),
+            Some(this) => {
+                let mut string = HString::default();
+                unsafe {
+                    ((*(*this.as_ptr()).as_ptr()).inspectable_type_name)(
+                        Some(this),
+                        string.set_abi(),
+                    )
+                    .ok()?;
+                }
+                Ok(string)
+            }
         }
-        let mut string = HString::default();
-        unsafe {
-            ((*(*(this))).inspectable_type_name)(this, string.set_abi()).ok()?;
-        }
-        Ok(string)
     }
 }
 

--- a/tests/com_interface.rs
+++ b/tests/com_interface.rs
@@ -23,7 +23,10 @@ fn com_interface() -> winrt::Result<()> {
     // The class and the non-default interface have different vtable types, which
     // means we need to cast in order to compare their pointers (which won't match).
     let s: IStringable = uri.into();
-    assert!(s.as_raw() as winrt::RawPtr != uri.as_raw() as winrt::RawPtr);
+    assert!(
+        s.as_raw().unwrap().cast::<*mut winrt::IUnknown>()
+            != uri.as_raw().unwrap().cast::<*mut winrt::IUnknown>()
+    );
 
     // Here two different values of the same class won't share the same value as
     // they are unique instances even though they have the same vtable layout.


### PR DESCRIPTION
This change moves: `RawComPtr` from `*mut *mut VTable` to `Option<NonNull<NonNull<Vtable>>`. This more correctly models reality that the ComPtrs can be null but they point to non-null pointers to vtables