### PR TITLE
Address use-after-free bug in delegates

### DIFF
--- a/crates/winmd/src/types/async_get.rs
+++ b/crates/winmd/src/types/async_get.rs
@@ -65,7 +65,7 @@ fn to_async_get_tokens(kind: AsyncKind, name: &TypeName, calling_namespace: &str
             if self.status()? == #namespace AsyncStatus::Started {
                 unsafe {
                     let event = ::winrt::runtime::CreateEventW(::std::ptr::null_mut(), 1, 0, ::std::ptr::null_mut());
-                    self.set_completed(#namespace #handler::new(|_sender, _args| {
+                    self.set_completed(#namespace #handler::new(move |_sender, _args| {
                         ::winrt::runtime::SetEvent(event);
                         Ok(())
                     }))?;

--- a/crates/winmd/src/types/delegate.rs
+++ b/crates/winmd/src/types/delegate.rs
@@ -208,7 +208,7 @@ impl Delegate {
             quote! { () }
         };
 
-        quote! { F: FnMut(#(#params)*) -> ::winrt::Result<#return_type> }
+        quote! { F: FnMut(#(#params)*) -> ::winrt::Result<#return_type> + 'static }
     }
 
     fn to_impl_definition_tokens(&self, fn_constraint: &TokenStream) -> TokenStream {

--- a/tests/delegates.rs
+++ b/tests/delegates.rs
@@ -22,10 +22,10 @@ fn non_generic() -> winrt::Result<()> {
     let d = Handler::default();
     assert!(d.is_null());
 
-    let mut invoked = false;
+    let (tx, rx) = std::sync::mpsc::channel();
 
-    let d = Handler::new(|info, status| {
-        invoked = true;
+    let d = Handler::new(move |info, status| {
+        tx.send(true).unwrap();
         assert!(info.is_null());
         assert!(status == AsyncStatus::Completed);
         Ok(())
@@ -35,7 +35,7 @@ fn non_generic() -> winrt::Result<()> {
     // to call them without an explicit `invoke` method e.g. `d(args);`
     d.invoke(IAsyncAction::default(), AsyncStatus::Completed)?;
 
-    assert!(invoked);
+    assert!(rx.recv().unwrap());
 
     Ok(())
 }
@@ -50,21 +50,23 @@ fn generic() -> winrt::Result<()> {
     let d = Handler::default();
     assert!(d.is_null());
 
-    let uri = &Uri::create_uri("http://kennykerr.ca")?;
-    let mut invoked = false;
+    let uri = Uri::create_uri("http://kennykerr.ca")?;
+    let (tx, rx) = std::sync::mpsc::channel();
 
-    let d = Handler::new(|sender, port| {
-        invoked = true;
-        assert!(uri.as_raw() == sender.as_raw());
+    let uri_clone = uri.clone();
+    let d = Handler::new(move |sender, port| {
+        tx.send(true).unwrap();
+        assert!(uri_clone.as_raw() == sender.as_raw());
 
         // TODO: ideally primitives would be passed by value
         assert!(*port == 80);
         Ok(())
     });
 
-    d.invoke(uri, uri.port()?)?;
+    let port = uri.port()?;
+    d.invoke(uri, port)?;
 
-    assert!(invoked);
+    assert!(rx.recv().unwrap());
 
     Ok(())
 }
@@ -74,14 +76,16 @@ fn event() -> winrt::Result<()> {
     use windows::foundation::collections::*;
     use windows::foundation::*;
 
-    let set = &PropertySet::new()?;
-    let mut invoked = false;
+    let set = PropertySet::new()?;
+    let (tx, rx) = std::sync::mpsc::channel();
 
+    let set_clone = set.clone();
     // TODO: Should be able to elide the delegate construction and simply say:
     // set.map_changed(|sender, args| {...})?;
     set.map_changed(
-        MapChangedEventHandler::<winrt::HString, winrt::Object>::new(|sender, args| {
-            invoked = true;
+        MapChangedEventHandler::<winrt::HString, winrt::Object>::new(move |sender, args| {
+            tx.send(true).unwrap();
+            let set = set_clone.clone();
             let map: IObservableMap<winrt::HString, winrt::Object> = set.into();
             assert!(map.as_raw() == sender.as_raw());
             assert!(args.key()? == "A");
@@ -92,7 +96,7 @@ fn event() -> winrt::Result<()> {
 
     set.insert("A", PropertyValue::create_uint32(1)?)?;
 
-    assert!(invoked);
+    assert!(rx.recv().unwrap());
 
     Ok(())
 }


### PR DESCRIPTION
Fixes #155 

Closures passed to delegate handlers are now `'static` meaning that they cannot contain any references. While this will work and is certainly more correct than what is currently in master, it is a bit more restrictive than it really needs to be.

One way we could loosen that restriction is by tying a lifetime to the handlers themselves and saying that the closures can have references that live as long as the handler does. I don't believe this will make the code that much more complicated and it will ultimately make it more useful. 