### PR TITLE
Fix GNU toolchain builds

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -22,7 +22,7 @@ extern "system" {
     ) -> u32;
 }
 
-#[link(name = "onecore")]
+#[link(name = "windowsapp")]
 extern "system" {
     pub fn CoIncrementMTAUsage(cookie: *mut RawPtr) -> ErrorCode;
 

--- a/tests/clipboard.rs
+++ b/tests/clipboard.rs
@@ -22,7 +22,7 @@
 //     Ok(())
 // }
 
-// #[link(name = "onecore")]
+// #[link(name = "windowsapp")]
 // extern "system" {
 //     pub fn CoInitializeEx(reserved: usize, apartment: u32) -> ErrorCode;
 // }


### PR DESCRIPTION
This PR fixes the GNU toolchain (-pc-windows-gnu) builds for the apps that use winrt-rs.

Note that it is still not possible to build all the tests in winrt-rs itself with the GNU toolchain, but with MSVC toolchain all the tests pass.

It is probably a temporary workaround, though I see that the TODO to dynamically load the APIs from OneCore has been removed.