### PR TITLE
Avoid the need for allowing overflowing_literals

### DIFF
--- a/crates/winmd/src/tables/attribute.rs
+++ b/crates/winmd/src/tables/attribute.rs
@@ -27,7 +27,7 @@ impl Attribute {
         }
     }
 
-    pub fn args(&self, reader: &TypeReader) -> Vec<(String, AttributeArg)> {
+    pub fn args(self, reader: &TypeReader) -> Vec<(String, AttributeArg)> {
         let (mut sig, mut values) = match self.constructor(reader) {
             AttributeType::MethodDef(method) => (reader.blob(method.0, 4), reader.blob(self.0, 2)),
             AttributeType::MemberRef(method) => (reader.blob(method.0, 2), reader.blob(self.0, 2)),

--- a/crates/winmd/src/types/enum.rs
+++ b/crates/winmd/src/types/enum.rs
@@ -66,7 +66,7 @@ impl Enum {
                 pub const #name: Self = Self { value: #value };
             }
         });
-        let bitwise = bitwise_operators(&name, &self.fields[0].1);
+        let bitwise = bitwise_operators(&name, self.fields[0].1);
 
         quote! {
             #[repr(transparent)]

--- a/crates/winmd/src/types/enum.rs
+++ b/crates/winmd/src/types/enum.rs
@@ -95,7 +95,7 @@ impl Enum {
     }
 }
 
-fn bitwise_operators(name: &TokenStream, value_type: &EnumConstant) -> TokenStream {
+fn bitwise_operators(name: &TokenStream, value_type: EnumConstant) -> TokenStream {
     match value_type {
         EnumConstant::I32(_) => return quote! {},
         _ => {}

--- a/crates/winmd/src/types/required_interfaces.rs
+++ b/crates/winmd/src/types/required_interfaces.rs
@@ -30,9 +30,8 @@ fn kind(reader: &TypeReader, required: InterfaceImpl) -> InterfaceKind {
     for attribute in required.attributes(reader) {
         let name = attribute.name(reader);
 
-        match name {
-            ("Windows.Foundation.Metadata", "DefaultAttribute") => return InterfaceKind::Default,
-            _ => {}
+        if let ("Windows.Foundation.Metadata", "DefaultAttribute") = name {
+            return InterfaceKind::Default;
         }
     }
 

--- a/crates/winmd/src/types/type_name.rs
+++ b/crates/winmd/src/types/type_name.rs
@@ -306,7 +306,7 @@ impl TypeName {
         {
             let cache = self.tokens.borrow();
 
-            if let Some(_) = cache.get(calling_namespace) {
+            if cache.get(calling_namespace).is_some() {
                 return Ref::map(cache, |s| s.get(calling_namespace).unwrap());
             }
         }

--- a/examples/nuget-dependency/src/main.rs
+++ b/examples/nuget-dependency/src/main.rs
@@ -1,5 +1,3 @@
-#![allow(overflowing_literals)]
-
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
 use windows::foundation::PropertyValue;

--- a/src/agile_object.rs
+++ b/src/agile_object.rs
@@ -11,7 +11,7 @@ unsafe impl ComInterface for IAgileObject {
 
     fn iid() -> Guid {
         Guid::from_values(
-            0x94EA2B94,
+            0x94EA_2B94,
             0xE9CC,
             0x49E0,
             [0xC0, 0xFF, 0xEE, 0x64, 0xCA, 0x8F, 0x5B, 0x90],

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,12 +1,10 @@
-#![allow(overflowing_literals)]
-
 use crate::runtime::*;
 use crate::*;
 
 /// The ErrorCode (a.k.a HRESULT) of an error
 #[repr(transparent)]
 #[derive(Copy, Clone, Debug, PartialEq)]
-pub struct ErrorCode(pub i32);
+pub struct ErrorCode(pub u32);
 
 /// A WinRT related error
 pub struct Error {
@@ -98,9 +96,9 @@ impl Error {
             }
         }
 
-        const FORMAT_MESSAGE_ALLOCATE_BUFFER: u32 = 0x00000100;
-        const FORMAT_MESSAGE_FROM_SYSTEM: u32 = 0x00001000;
-        const FORMAT_MESSAGE_IGNORE_INSERTS: u32 = 0x00000200;
+        const FORMAT_MESSAGE_ALLOCATE_BUFFER: u32 = 0x0000_0100;
+        const FORMAT_MESSAGE_FROM_SYSTEM: u32 = 0x0000_1000;
+        const FORMAT_MESSAGE_IGNORE_INSERTS: u32 = 0x0000_0200;
         let mut message = HeapString::new();
 
         unsafe {
@@ -110,7 +108,7 @@ impl Error {
                     | FORMAT_MESSAGE_IGNORE_INSERTS,
                 std::ptr::null_mut(),
                 self.code,
-                0x00000400, // MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT)
+                0x0000_0400, // MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT)
                 &mut message.ptr,
                 0,
                 std::ptr::null_mut(),
@@ -138,12 +136,12 @@ impl std::fmt::Debug for Error {
 impl ErrorCode {
     #[inline]
     pub fn is_ok(self) -> bool {
-        self.0 >= 0
+        self.0 & 0x8000_0000 == 0
     }
 
     #[inline]
     pub fn is_err(self) -> bool {
-        self.0 < 0
+        !self.is_ok()
     }
 
     #[inline]

--- a/tests/error.rs
+++ b/tests/error.rs
@@ -1,5 +1,3 @@
-#![allow(overflowing_literals)]
-
 winrt::import!(
     dependencies
         os


### PR DESCRIPTION
Fixes #164 

HRESULT is traditionally defined as a signed 32-bit integer but we don't need to do so in Rust so long as we handle Severity bit checks (bit 31) properly.

Also fixed a few code tidiness issues.