### PR TITLE
NonNullRawComPtr

### DIFF
--- a/crates/winmd/src/types/class.rs
+++ b/crates/winmd/src/types/class.rs
@@ -125,7 +125,7 @@ impl Class {
             quote! {
                 #[repr(transparent)]
                 #[derive(Default, Clone, PartialEq)]
-                pub struct #name { ptr: ::winrt::ComPtr<#name> }
+                pub struct #name { ptr: ::winrt::ComPtr<#default_name> }
                 impl #name {
                     #new
                     #methods
@@ -139,12 +139,12 @@ impl Class {
                     }
                 }
                 unsafe impl ::winrt::RuntimeType for #name {
-                    type Abi = ::winrt::RawComPtr<Self>;
+                    type Abi = ::winrt::RawComPtr<#default_name>;
                     fn signature() -> String {
                         #signature.to_owned()
                     }
                     fn abi(&self) -> Self::Abi {
-                        <::winrt::ComPtr<Self> as ::winrt::ComInterface>::as_raw(&self.ptr)
+                        self.ptr.abi()
                     }
                     fn set_abi(&mut self) -> *mut Self::Abi {
                         self.ptr.set_abi()

--- a/crates/winmd/src/types/delegate.rs
+++ b/crates/winmd/src/types/delegate.rs
@@ -176,7 +176,7 @@ impl Delegate {
                 }
                 extern "system" fn unknown_release(this: ::winrt::NonNullRawComPtr<::winrt::IUnknown>) -> u32 {
                     unsafe {
-                        let this: *mut Self = this.as_raw() as _;                        let remaining = (*this).count.release();
+                        let this: *mut Self = this.as_raw() as _;
                         let remaining = (*this).count.release();
 
                         if remaining == 0 {

--- a/crates/winmd/src/types/delegate.rs
+++ b/crates/winmd/src/types/delegate.rs
@@ -88,9 +88,9 @@ impl Delegate {
             }
             #[repr(C)]
             pub struct #abi_definition where #constraints {
-                pub unknown_query_interface: extern "system" fn(::winrt::RawComPtr<::winrt::IUnknown>, &::winrt::Guid, *mut ::winrt::RawPtr) -> ::winrt::ErrorCode,
-                pub unknown_add_ref: extern "system" fn(::winrt::RawComPtr<::winrt::IUnknown>) -> u32,
-                pub unknown_release: extern "system" fn(::winrt::RawComPtr<::winrt::IUnknown>) -> u32,
+                pub unknown_query_interface: extern "system" fn(::winrt::NonNullRawComPtr<::winrt::IUnknown>, &::winrt::Guid, *mut ::winrt::RawPtr) -> ::winrt::ErrorCode,
+                pub unknown_add_ref: extern "system" fn(::winrt::NonNullRawComPtr<::winrt::IUnknown>) -> u32,
+                pub unknown_release: extern "system" fn(::winrt::NonNullRawComPtr<::winrt::IUnknown>) -> u32,
                 #abi_method
                 #phantoms
             }
@@ -148,12 +148,12 @@ impl Delegate {
                     }
                 }
                 extern "system" fn unknown_query_interface(
-                    this: ::winrt::RawComPtr<::winrt::IUnknown>,
+                    this: ::winrt::NonNullRawComPtr<::winrt::IUnknown>,
                     iid: &::winrt::Guid,
                     interface: *mut ::winrt::RawPtr,
                 ) -> ::winrt::ErrorCode {
                     unsafe {
-                        let this: *mut Self = this.unwrap().as_raw() as _;
+                        let this: *mut Self = this.as_raw() as _;
 
                         if iid == &<#name as ::winrt::ComInterface>::iid()
                             || iid == &<::winrt::IUnknown as ::winrt::ComInterface>::iid()
@@ -168,15 +168,15 @@ impl Delegate {
                         ::winrt::ErrorCode(0x80004002)
                     }
                 }
-                extern "system" fn unknown_add_ref(this: ::winrt::RawComPtr<::winrt::IUnknown>) -> u32 {
+                extern "system" fn unknown_add_ref(this: ::winrt::NonNullRawComPtr<::winrt::IUnknown>) -> u32 {
                     unsafe {
-                        let this: *mut Self = this.unwrap().as_raw() as _;
+                        let this: *mut Self = this.as_raw() as _;
                         (*this).count.add_ref()
                     }
                 }
-                extern "system" fn unknown_release(this: ::winrt::RawComPtr<::winrt::IUnknown>) -> u32 {
+                extern "system" fn unknown_release(this: ::winrt::NonNullRawComPtr<::winrt::IUnknown>) -> u32 {
                     unsafe {
-                        let this: *mut Self = this.unwrap().as_raw() as _;                        let remaining = (*this).count.release();
+                        let this: *mut Self = this.as_raw() as _;                        let remaining = (*this).count.release();
                         let remaining = (*this).count.release();
 
                         if remaining == 0 {
@@ -188,7 +188,7 @@ impl Delegate {
                 }
                 #invoke_sig {
                     unsafe {
-                        let this: *mut Self = this.unwrap().as_raw() as _;
+                        let this: *mut Self = this.as_raw() as _;
                         ((*this).invoke)(#(#invoke_args,)*).into()
                     }
                 }

--- a/crates/winmd/src/types/delegate.rs
+++ b/crates/winmd/src/types/delegate.rs
@@ -100,7 +100,7 @@ impl Delegate {
                     #signature
                 }
                 fn abi(&self) -> Self::Abi {
-                    <::winrt::ComPtr<Self> as ::winrt::ComInterface>::as_raw(&self.ptr)
+                    self.ptr.abi()
                 }
                 fn set_abi(&mut self) -> *mut Self::Abi {
                     self.ptr.set_abi()
@@ -142,8 +142,8 @@ impl Delegate {
                     };
                     unsafe {
                         let mut result: #name = std::mem::zeroed();
-                        let ptr = ::std::ptr::NonNull::new_unchecked(::std::boxed::Box::into_raw(::std::boxed::Box::new(value)));
-                        *<#name as ::winrt::RuntimeType>::set_abi(&mut result) = Some(ptr.cast());
+                        let ptr: ::std::ptr::NonNull<Self> = ::std::ptr::NonNull::new_unchecked(::std::boxed::Box::into_raw(::std::boxed::Box::new(value)));
+                        *<#name as ::winrt::RuntimeType>::set_abi(&mut result) = Some(::winrt::NonNullRawComPtr::new(ptr.cast()));
                         result
                     }
                 }
@@ -153,7 +153,7 @@ impl Delegate {
                     interface: *mut ::winrt::RawPtr,
                 ) -> ::winrt::ErrorCode {
                     unsafe {
-                        let this: *mut Self = this.map(|s| s.cast::<Self>()).unwrap().as_ptr();
+                        let this: *mut Self = this.unwrap().as_raw() as _;
 
                         if iid == &<#name as ::winrt::ComInterface>::iid()
                             || iid == &<::winrt::IUnknown as ::winrt::ComInterface>::iid()
@@ -170,13 +170,13 @@ impl Delegate {
                 }
                 extern "system" fn unknown_add_ref(this: ::winrt::RawComPtr<::winrt::IUnknown>) -> u32 {
                     unsafe {
-                        let this: *mut Self = this.map(|s| s.cast::<Self>()).unwrap().as_ptr();
+                        let this: *mut Self = this.unwrap().as_raw() as _;
                         (*this).count.add_ref()
                     }
                 }
                 extern "system" fn unknown_release(this: ::winrt::RawComPtr<::winrt::IUnknown>) -> u32 {
                     unsafe {
-                        let this: *mut Self = this.map(|s| s.cast::<Self>()).unwrap().as_ptr();
+                        let this: *mut Self = this.unwrap().as_raw() as _;                        let remaining = (*this).count.release();
                         let remaining = (*this).count.release();
 
                         if remaining == 0 {
@@ -188,8 +188,7 @@ impl Delegate {
                 }
                 #invoke_sig {
                     unsafe {
-                        let this: *mut Self = this.map(|s| s.cast::<Self>()).unwrap().as_ptr();
-
+                        let this: *mut Self = this.unwrap().as_raw() as _;
                         ((*this).invoke)(#(#invoke_args,)*).into()
                     }
                 }

--- a/crates/winmd/src/types/interface.rs
+++ b/crates/winmd/src/types/interface.rs
@@ -112,7 +112,7 @@ impl Interface {
                     #signature
                 }
                 fn abi(&self) -> Self::Abi {
-                    <::winrt::ComPtr<Self> as ::winrt::ComInterface>::as_raw(&self.ptr)
+                    self.ptr.abi()
                 }
                 fn set_abi(&mut self) -> *mut Self::Abi {
                     self.ptr.set_abi()

--- a/crates/winmd/src/types/interface.rs
+++ b/crates/winmd/src/types/interface.rs
@@ -97,12 +97,7 @@ impl Interface {
             }
             #[repr(C)]
             pub struct #abi_definition where #constraints {
-                pub unknown_query_interface: extern "system" fn(::winrt::RawComPtr<::winrt::IUnknown>, &::winrt::Guid, *mut ::winrt::RawPtr) -> ::winrt::ErrorCode,
-                pub unknown_add_ref: extern "system" fn(::winrt::RawComPtr<::winrt::IUnknown>) -> u32,
-                pub unknown_release: extern "system" fn(::winrt::RawComPtr<::winrt::IUnknown>) -> u32,
-                pub inspectable_iids: extern "system" fn(::winrt::RawComPtr<::winrt::Object>, *mut u32, *mut *mut ::winrt::Guid) -> ::winrt::ErrorCode,
-                pub inspectable_type_name: extern "system" fn(::winrt::RawComPtr<::winrt::Object>, *mut <::winrt::HString as ::winrt::RuntimeType>::Abi) -> ::winrt::ErrorCode,
-                pub inspectable_trust_level: extern "system" fn(::winrt::RawComPtr<::winrt::Object>, *mut i32) -> ::winrt::ErrorCode,
+                __base: [ usize; 6],
                 #abi_methods
                 #phantoms
             }

--- a/crates/winmd/src/types/method.rs
+++ b/crates/winmd/src/types/method.rs
@@ -143,7 +143,7 @@ impl Method {
         );
 
         quote! {
-            pub #name: extern "system" fn(::winrt::RawComPtr<#type_name>, #params) -> ::winrt::ErrorCode,
+            pub #name: extern "system" fn(::winrt::NonNullRawComPtr<#type_name>, #params) -> ::winrt::ErrorCode,
         }
     }
 
@@ -161,7 +161,7 @@ impl Method {
             });
 
         quote! {
-            extern "system" fn #name(this: ::winrt::RawComPtr<#type_name>, #(#params)*) -> ::winrt::ErrorCode
+            extern "system" fn #name(this: ::winrt::NonNullRawComPtr<#type_name>, #(#params)*) -> ::winrt::ErrorCode
         }
     }
 
@@ -234,7 +234,7 @@ impl Method {
                         Some(this) => {
                             unsafe {
                                 let mut __ok: #return_type = ::std::mem::zeroed();
-                                (this.vtable().#method_name)(Some(this), #args #return_arg)
+                                (this.vtable().#method_name)(this, #args #return_arg)
                                     .and_then(|| __ok )
                             }
                         }
@@ -248,7 +248,7 @@ impl Method {
                         None => panic!("The `this` pointer was null when calling method"),
                         Some(this) => {
                             unsafe {
-                                (this.vtable().#method_name)(Some(this), #args).ok()
+                                (this.vtable().#method_name)(this, #args).ok()
                             }
                         }
                     }

--- a/crates/winmd/src/types/method.rs
+++ b/crates/winmd/src/types/method.rs
@@ -229,14 +229,12 @@ impl Method {
 
             quote! {
                 pub fn #method_name<#constraints>(&self, #params) -> ::winrt::Result<#return_type> {
-                    let this = <::winrt::ComPtr<Self> as ::winrt::ComInterface>::as_raw(&self.ptr);
-
-                    match this {
+                    match self.ptr.abi() {
                         None => panic!("The `this` pointer was null when calling method"),
                         Some(this) => {
                             unsafe {
                                 let mut __ok: #return_type = ::std::mem::zeroed();
-                                ((*(*this.as_ptr()).as_ptr()).#method_name)(Some(this), #args #return_arg)
+                                (this.vtable().#method_name)(Some(this), #args #return_arg)
                                     .and_then(|| __ok )
                             }
                         }
@@ -246,13 +244,11 @@ impl Method {
         } else {
             quote! {
                 pub fn #method_name<#constraints>(&self, #params) -> ::winrt::Result<()> {
-                    let this = <::winrt::ComPtr<Self> as ::winrt::ComInterface>::as_raw(&self.ptr);
-
-                    match this {
+                    match self.ptr.abi() {
                         None => panic!("The `this` pointer was null when calling method"),
                         Some(this) => {
                             unsafe {
-                                ((*(*this.as_ptr()).as_ptr()).#method_name)(Some(this), #args).ok()
+                                (this.vtable().#method_name)(Some(this), #args).ok()
                             }
                         }
                     }

--- a/src/agile_object.rs
+++ b/src/agile_object.rs
@@ -22,7 +22,7 @@ unsafe impl ComInterface for IAgileObject {
 #[repr(C)]
 pub struct abi_IAgileObject {
     pub unknown_query_interface:
-        extern "system" fn(RawComPtr<IUnknown>, &Guid, *mut RawPtr) -> ErrorCode,
-    pub unknown_add_ref: extern "system" fn(RawComPtr<IUnknown>) -> u32,
-    pub unknown_release: extern "system" fn(RawComPtr<IUnknown>) -> u32,
+        unsafe extern "system" fn(RawComPtr<IUnknown>, &Guid, *mut RawPtr) -> ErrorCode,
+    pub unknown_add_ref: unsafe extern "system" fn(RawComPtr<IUnknown>) -> u32,
+    pub unknown_release: unsafe extern "system" fn(RawComPtr<IUnknown>) -> u32,
 }

--- a/src/com_ptr.rs
+++ b/src/com_ptr.rs
@@ -13,12 +13,11 @@ impl<T: ComInterface> ComPtr<T> {
 
     pub fn set_abi(&mut self) -> *mut RawComPtr<T> {
         if let Some(ptr) = self.as_iunknown() {
-            unsafe {
-                ((*(*ptr.as_ptr()).as_ptr()).unknown_release)(self.as_iunknown());
-            }
+            (ptr.vtable().unknown_release)(ptr);
+
             self.ptr = None;
         }
-        &mut self.ptr as *mut _ as _
+        &mut self.ptr
     }
 }
 
@@ -33,7 +32,7 @@ unsafe impl<T: ComInterface> ComInterface for ComPtr<T> {
 impl<T: ComInterface> Clone for ComPtr<T> {
     fn clone(&self) -> Self {
         if let Some(ptr) = self.as_iunknown() {
-            unsafe { ((*(*ptr.as_ptr()).as_ptr()).unknown_add_ref)(self.as_iunknown()) };
+            (ptr.vtable().unknown_add_ref)(ptr);
         }
         Self { ptr: self.ptr }
     }
@@ -42,7 +41,7 @@ impl<T: ComInterface> Clone for ComPtr<T> {
 impl<T: ComInterface> Drop for ComPtr<T> {
     fn drop(&mut self) {
         if let Some(ptr) = self.as_iunknown() {
-            unsafe { ((*(*ptr.as_ptr()).as_ptr()).unknown_release)(self.as_iunknown()) };
+            (ptr.vtable().unknown_release)(ptr);
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -23,7 +23,7 @@ impl<T> std::convert::From<Result<T>> for ErrorCode {
         if let Err(error) = result {
             if let Some(info) = error.info.as_raw() {
                 unsafe {
-                    SetRestrictedErrorInfo(info.as_ptr() as _);
+                    SetRestrictedErrorInfo(info.as_raw() as _);
                 }
             }
 
@@ -265,13 +265,10 @@ impl IErrorInfo {
 
     pub fn get_description(&self) -> String {
         let mut description = BString::new();
-        match self.ptr.as_raw() {
+        match self.ptr.abi() {
             Some(p) => {
                 unsafe {
-                    ((*(*p.as_ptr()).as_ptr()).get_description)(
-                        self.ptr.as_raw(),
-                        description.set_abi(),
-                    );
+                    (p.vtable().get_description)(Some(p), description.set_abi());
                 }
 
                 description.into()
@@ -297,7 +294,7 @@ unsafe impl ComInterface for IErrorInfo {
 #[repr(C)]
 struct abi_IErrorInfo {
     __base: [usize; 5],
-    get_description: extern "system" fn(RawComPtr<IErrorInfo>, *mut *mut u16) -> ErrorCode,
+    get_description: unsafe extern "system" fn(RawComPtr<IErrorInfo>, *mut *mut u16) -> ErrorCode,
 }
 
 #[repr(transparent)]
@@ -312,13 +309,13 @@ impl IRestrictedErrorInfo {
         let mut message = BString::new();
         let mut unused = BString::new();
         let mut code = ErrorCode(0);
-        let p = match self.ptr.as_raw() {
+        let p = match self.ptr.abi() {
             Some(p) => p,
             None => return (code, String::new()),
         };
 
         unsafe {
-            ((*(*p.as_ptr()).as_ptr()).get_error_details)(
+            (p.vtable().get_error_details)(
                 Some(p),
                 fallback.set_abi(),
                 &mut code,
@@ -353,7 +350,7 @@ unsafe impl ComInterface for IRestrictedErrorInfo {
 #[repr(C)]
 struct abi_IRestrictedErrorInfo {
     __base: [usize; 3],
-    get_error_details: extern "system" fn(
+    get_error_details: unsafe extern "system" fn(
         RawComPtr<IRestrictedErrorInfo>,
         *mut *mut u16,
         *mut ErrorCode,
@@ -370,12 +367,9 @@ struct ILanguageExceptionErrorInfo2 {
 
 impl ILanguageExceptionErrorInfo2 {
     pub fn capture_propagation_context(&self) {
-        if let Some(p) = self.ptr.as_raw() {
+        if let Some(p) = self.ptr.abi() {
             unsafe {
-                ((*(*p.as_ptr()).as_ptr()).capture_propagation_context)(
-                    self.ptr.as_raw(),
-                    std::ptr::null_mut(),
-                );
+                (p.vtable().capture_propagation_context)(p, std::ptr::null_mut());
             }
         }
     }
@@ -397,6 +391,8 @@ unsafe impl ComInterface for ILanguageExceptionErrorInfo2 {
 #[repr(C)]
 struct abi_ILanguageExceptionErrorInfo2 {
     __base: [usize; 5],
-    capture_propagation_context:
-        extern "system" fn(RawComPtr<ILanguageExceptionErrorInfo2>, RawPtr) -> ErrorCode,
+    capture_propagation_context: unsafe extern "system" fn(
+        NonNullRawComPtr<ILanguageExceptionErrorInfo2>,
+        RawPtr,
+    ) -> ErrorCode,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@ mod unknown;
 pub use activation_factory::IActivationFactory;
 pub use agile_object::IAgileObject;
 pub use array::Array;
-pub use com_interface::{ComInterface, RawComPtr};
+pub use com_interface::{ComInterface, NonNullRawComPtr, RawComPtr};
 pub use com_ptr::ComPtr;
 pub use error::*;
 pub use factory::factory;

--- a/src/try_into.rs
+++ b/src/try_into.rs
@@ -11,16 +11,12 @@ impl<From: ComInterface + Sized, Into: ComInterface> TryInto<Into> for &From {
         let from = self.as_iunknown();
 
         if let Some(ptr) = from {
-            unsafe {
-                ((*(*ptr.as_ptr()).as_ptr()).unknown_query_interface)(
-                    Some(ptr),
-                    &Into::iid(),
-                    &mut into,
-                )
-                .ok()?
-            };
+            unsafe { (ptr.vtable().unknown_query_interface)(ptr, &Into::iid(), &mut into).ok()? };
 
-            debug_assert!(!into.is_null());
+            debug_assert!(
+                !into.is_null(),
+                "Null pointer found after successful QueryInterface call"
+            );
         }
 
         unsafe { Ok(std::mem::transmute_copy(&into)) }

--- a/src/unknown.rs
+++ b/src/unknown.rs
@@ -29,7 +29,7 @@ unsafe impl ComInterface for IUnknown {
 #[repr(C)]
 pub struct abi_IUnknown {
     pub unknown_query_interface:
-        extern "system" fn(RawComPtr<IUnknown>, &Guid, *mut RawPtr) -> ErrorCode,
-    pub unknown_add_ref: extern "system" fn(RawComPtr<IUnknown>) -> u32,
-    pub unknown_release: extern "system" fn(RawComPtr<IUnknown>) -> u32,
+        unsafe extern "system" fn(NonNullRawComPtr<IUnknown>, &Guid, *mut RawPtr) -> ErrorCode,
+    pub unknown_add_ref: extern "system" fn(NonNullRawComPtr<IUnknown>) -> u32,
+    pub unknown_release: extern "system" fn(NonNullRawComPtr<IUnknown>) -> u32,
 }

--- a/tests/com_interface.rs
+++ b/tests/com_interface.rs
@@ -8,6 +8,7 @@ winrt::import!(
 #[test]
 fn com_interface() -> winrt::Result<()> {
     use winrt::ComInterface;
+    use winrt::RuntimeType;
 
     use windows::foundation::IStringable;
     use windows::foundation::IUriRuntimeClass;
@@ -18,20 +19,21 @@ fn com_interface() -> winrt::Result<()> {
     // The class and the default interface have the same vtable types, which
     // means you can compare them directly.
     let u: IUriRuntimeClass = uri.into();
-    assert!(u.as_raw() == uri.as_raw());
+    assert!(u.abi() == uri.abi());
 
     // The class and the non-default interface have different vtable types, which
     // means we need to cast in order to compare their pointers (which won't match).
     let s: IStringable = uri.into();
-    assert!(
-        s.as_raw().unwrap().cast::<*mut winrt::IUnknown>()
-            != uri.as_raw().unwrap().cast::<*mut winrt::IUnknown>()
-    );
-
+    unsafe {
+        assert!(
+            s.abi().unwrap().cast::<winrt::IUnknown>()
+                != uri.abi().unwrap().cast::<winrt::IUnknown>()
+        );
+    }
     // Here two different values of the same class won't share the same value as
     // they are unique instances even though they have the same vtable layout.
     let other = &Uri::create_uri("http://microsoft.com")?;
-    assert!(uri.as_raw() != other.as_raw());
+    assert!(uri.abi() != other.abi());
 
     // A default constructor class will always have a null vtable pointer.
     let uri = Uri::default();


### PR DESCRIPTION
Building off of #162, this provides an explicit type for `RawComPtr`s that are known to be non-null. This mostly happens at ABI function calling boundary. The code now forces that nulls have been checked and that the  `this` pointer is not null. 

The name `NonNullRawComPtr` is pretty terrible, but it is descriptive. Suggestions on improvements are more than welcome. 