### PR TITLE
multi-word namespace test

### DIFF
--- a/tests/namespace.rs
+++ b/tests/namespace.rs
@@ -1,0 +1,19 @@
+// This test ensures that a multi-word namespace "MachineLearning" is properly
+// converted to "machine_learning" and imports correctly.
+
+winrt::import!(
+    dependencies
+        os
+    types
+        windows::ai::machine_learning::*
+);
+
+#[test]
+fn namespace() -> winrt::Result<()> {
+    use windows::ai::machine_learning::{TensorBoolean, TensorKind};
+
+    let tensor = TensorBoolean::create()?;
+    assert!(tensor.tensor_kind()? == TensorKind::Boolean);
+
+    Ok(())
+}


### PR DESCRIPTION
This test ensures that a multi-word namespace "MachineLearning" is properly converted to "machine_learning" and imports correctly.

The code around converting and importing namespaces is a little brittle since it is inherently a lossy conversion. This test just ensures we don't regress this.