### PR TITLE
Move signatures to being static

### DIFF
--- a/crates/winmd/src/types/class.rs
+++ b/crates/winmd/src/types/class.rs
@@ -139,8 +139,8 @@ impl Class {
                     }
                 }
                 unsafe impl ::winrt::RuntimeType for #name {
-                    fn signature() -> String {
-                        #signature.to_owned()
+                    fn signature() -> &'static str {
+                        #signature
                     }
                 }
                 unsafe impl ::winrt::AbiTransferable for #name {

--- a/crates/winmd/src/types/delegate.rs
+++ b/crates/winmd/src/types/delegate.rs
@@ -95,7 +95,7 @@ impl Delegate {
                 #phantoms
             }
             unsafe impl<#constraints> ::winrt::RuntimeType for #name {
-                fn signature() -> String {
+                fn signature() -> &'static str {
                     #signature
                 }
             }

--- a/crates/winmd/src/types/enum.rs
+++ b/crates/winmd/src/types/enum.rs
@@ -79,8 +79,8 @@ impl Enum {
                 #(#fields)*
             }
             unsafe impl ::winrt::RuntimeType for #name {
-                fn signature() -> String {
-                    #signature.to_owned()
+                fn signature() -> &'static str {
+                    #signature
                 }
             }
             unsafe impl ::winrt::AbiTransferable for #name {

--- a/crates/winmd/src/types/interface.rs
+++ b/crates/winmd/src/types/interface.rs
@@ -102,7 +102,7 @@ impl Interface {
                 #phantoms
             }
             unsafe impl<#constraints> ::winrt::RuntimeType for #name {
-                fn signature() -> String {
+                fn signature() -> &'static str {
                     #signature
                 }
             }

--- a/crates/winmd/src/types/struct.rs
+++ b/crates/winmd/src/types/struct.rs
@@ -57,8 +57,8 @@ impl Struct {
                 #(#fields),*
             }
             unsafe impl ::winrt::RuntimeType for #name {
-                fn signature() -> String {
-                    #signature.to_owned()
+                fn signature() -> &'static str {
+                    #signature
                 }
             }
             unsafe impl ::winrt::AbiTransferable for #name {

--- a/crates/winmd/src/types/type_name.rs
+++ b/crates/winmd/src/types/type_name.rs
@@ -104,7 +104,7 @@ impl TypeName {
 
     pub fn to_signature_tokens(&self, signature: &str) -> TokenStream {
         if self.generics.is_empty() {
-            return quote! { #signature.to_owned() };
+            return quote! { #signature };
         }
 
         // TODO: I'm sure there's a more generic way of doing this, but as of now there are at
@@ -123,7 +123,15 @@ impl TypeName {
         };
 
         quote! {
-            #format
+            static mut VAL: &'static str = "";
+            static INIT: ::std::sync::Once = ::std::sync::Once::new();
+            unsafe {
+                INIT.call_once(|| {
+                    VAL = ::std::boxed::Box::leak(#format.into_boxed_str());
+                });
+                VAL
+            }
+
         }
     }
 

--- a/src/guid.rs
+++ b/src/guid.rs
@@ -75,8 +75,8 @@ unsafe impl AbiTransferable for Guid {
     }
 }
 unsafe impl RuntimeType for Guid {
-    fn signature() -> String {
-        "g16".to_owned()
+    fn signature() -> &'static str {
+        "g16"
     }
 }
 

--- a/src/hstring.rs
+++ b/src/hstring.rs
@@ -84,8 +84,8 @@ unsafe impl AbiTransferable for HString {
 }
 
 unsafe impl RuntimeType for HString {
-    fn signature() -> String {
-        "string".to_owned()
+    fn signature() -> &'static str {
+        "string"
     }
 }
 

--- a/src/object.rs
+++ b/src/object.rs
@@ -39,8 +39,8 @@ unsafe impl ComInterface for Object {
 }
 
 unsafe impl RuntimeType for Object {
-    fn signature() -> String {
-        "cinterface(IInspectable)".to_owned()
+    fn signature() -> &'static str {
+        "cinterface(IInspectable)"
     }
 }
 

--- a/src/runtime_type.rs
+++ b/src/runtime_type.rs
@@ -9,18 +9,18 @@
 /// across FFI boundaries. The type itself must also be zero-initializable and safe to
 /// drop if all bits are zeroable. RuntimeTypes must be safe to use in WinRT generics.
 pub unsafe trait RuntimeType: crate::AbiTransferable {
-    // TODO: this should be a const function returning &'static str
+    // TODO: this should be a const
     // It is only used internally by ComInterface::iid() which should
     // itself be a const function.
-    fn signature() -> String;
+    fn signature() -> &'static str;
 }
 
 macro_rules! primitive_runtime_type {
     ($(($t:ty, $s:literal)),+) => {
         $(unsafe impl RuntimeType for $t {
 
-            fn signature() -> String {
-                $s.to_owned()
+            fn signature() -> &'static str {
+                $s
             }
         })*
     };


### PR DESCRIPTION
This makes `RuntimeType::signature` calls return a static reference. For the one place where we need to allocate, we cache into a global.

This is only temporary as eventually we'll do all of this at compile time, but at least now the type returned is the correct one. 