### PR TITLE
Docs

### DIFF
--- a/crates/winmd/src/types/async_get.rs
+++ b/crates/winmd/src/types/async_get.rs
@@ -64,13 +64,13 @@ fn to_async_get_tokens(kind: AsyncKind, name: &TypeName, calling_namespace: &str
         pub fn get(&self) -> ::winrt::Result<#return_type> {
             if self.status()? == #namespace AsyncStatus::Started {
                 unsafe {
-                    let event = ::winrt::runtime::CreateEventW(::std::ptr::null_mut(), 1, 0, ::std::ptr::null_mut());
+                    let event = ::winrt::CreateEventW(::std::ptr::null_mut(), 1, 0, ::std::ptr::null_mut());
                     self.set_completed(#namespace #handler::new(move |_sender, _args| {
-                        ::winrt::runtime::SetEvent(event);
+                        ::winrt::SetEvent(event);
                         Ok(())
                     }))?;
-                    ::winrt::runtime::WaitForSingleObject(event, 0xFFFFFFFF);
-                    ::winrt::runtime::CloseHandle(event);
+                    ::winrt::WaitForSingleObject(event, 0xFFFFFFFF);
+                    ::winrt::CloseHandle(event);
                 }
             }
             self.get_results()

--- a/src/com/mod.rs
+++ b/src/com/mod.rs
@@ -11,5 +11,5 @@ pub use interface::ComInterface;
 pub use ptr::ComPtr;
 pub use raw_ptr::{NonNullRawComPtr, RawComPtr};
 pub use ref_count::RefCount;
-pub use unknown::{IUnknown, abi_IUnknown};
 pub use try_into::TryInto;
+pub use unknown::{abi_IUnknown, IUnknown};

--- a/src/com/mod.rs
+++ b/src/com/mod.rs
@@ -4,10 +4,12 @@ mod interface;
 mod ptr;
 mod raw_ptr;
 mod ref_count;
-pub(crate) mod unknown;
+mod try_into;
+mod unknown;
 
 pub use interface::ComInterface;
 pub use ptr::ComPtr;
 pub use raw_ptr::{NonNullRawComPtr, RawComPtr};
 pub use ref_count::RefCount;
-pub use unknown::IUnknown;
+pub use unknown::{IUnknown, abi_IUnknown};
+pub use try_into::TryInto;

--- a/src/com/ptr.rs
+++ b/src/com/ptr.rs
@@ -1,4 +1,4 @@
-use super::{ComInterface, RawComPtr, IUnknown};
+use super::{ComInterface, IUnknown, RawComPtr};
 use crate::{AbiTransferable, Guid};
 
 /// A reference counted pointer to a COM interface.

--- a/src/com/ptr.rs
+++ b/src/com/ptr.rs
@@ -1,4 +1,4 @@
-use super::{interface::ComInterface, raw_ptr::RawComPtr, unknown::IUnknown};
+use super::{ComInterface, RawComPtr, IUnknown};
 use crate::{AbiTransferable, Guid};
 
 /// A reference counted pointer to a COM interface.

--- a/src/com/raw_ptr.rs
+++ b/src/com/raw_ptr.rs
@@ -1,4 +1,4 @@
-use super::{ComInterface,IUnknown};
+use super::{ComInterface, IUnknown};
 use crate::{AbiTransferable, Guid};
 
 /// A non-reference-counted pointer to a COM interface.

--- a/src/com/raw_ptr.rs
+++ b/src/com/raw_ptr.rs
@@ -1,5 +1,4 @@
-use super::interface::ComInterface;
-use super::unknown::IUnknown;
+use super::{ComInterface,IUnknown};
 use crate::{AbiTransferable, Guid};
 
 /// A non-reference-counted pointer to a COM interface.

--- a/src/com/try_into.rs
+++ b/src/com/try_into.rs
@@ -1,6 +1,5 @@
-use super::{ComInterface};
-use crate::{ Result};
-
+use super::ComInterface;
+use crate::Result;
 
 /// An equivalent to `std::convert::TryInto` for converting between interfaces.
 pub trait TryInto<T: ComInterface> {

--- a/src/com/try_into.rs
+++ b/src/com/try_into.rs
@@ -1,4 +1,6 @@
-use crate::{ComInterface, Result};
+use super::{ComInterface};
+use crate::{ Result};
+
 
 /// An equivalent to `std::convert::TryInto` for converting between interfaces.
 pub trait TryInto<T: ComInterface> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,3 @@
-use crate::runtime::*;
 use crate::*;
 
 /// An `ErrorCode`, sometimes called an `HRESULT`, is the error code associated with a WinRT error.

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -1,4 +1,3 @@
-use crate::runtime::*;
 use crate::*;
 
 /// Attempts to load the factory interface for the given WinRT class.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,6 @@ mod param;
 mod runtime;
 mod runtime_name;
 mod runtime_type;
-mod try_into;
 
 #[doc(hidden)]
 pub use abi_transferable::AbiTransferable;
@@ -85,8 +84,6 @@ pub use runtime::*;
 pub use runtime_name::RuntimeName;
 #[doc(hidden)]
 pub use runtime_type::RuntimeType;
-#[doc(hidden)]
-pub use try_into::TryInto;
 pub use winrt_macros::{build, import};
 
 #[doc(hidden)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,33 +51,43 @@ mod agile_object;
 mod array;
 mod com;
 mod error;
-#[doc(hidden)]
-pub mod factory;
+mod factory;
 mod guid;
 mod hstring;
 mod object;
 mod param;
-pub mod runtime;
+mod runtime;
 mod runtime_name;
 mod runtime_type;
 mod try_into;
 
+#[doc(hidden)]
 pub use abi_transferable::AbiTransferable;
-#[doc(inline)]
+#[doc(hidden)]
 pub use activation_factory::IActivationFactory;
+#[doc(hidden)]
 pub use agile_object::IAgileObject;
 pub use array::Array;
+#[doc(hidden)]
 pub use com::*;
 pub use error::*;
+#[doc(hidden)]
 pub use factory::factory;
+#[doc(hidden)]
 pub use guid::Guid;
 pub use hstring::HString;
 pub use object::Object;
+#[doc(hidden)]
 pub use param::Param;
+#[doc(hidden)]
+pub use runtime::*;
+#[doc(hidden)]
 pub use runtime_name::RuntimeName;
+#[doc(hidden)]
 pub use runtime_type::RuntimeType;
+#[doc(hidden)]
 pub use try_into::TryInto;
 pub use winrt_macros::{build, import};
 
-/// A convenient alias of a void pointer
+#[doc(hidden)]
 pub type RawPtr = *mut std::ffi::c_void;

--- a/src/object.rs
+++ b/src/object.rs
@@ -58,7 +58,7 @@ unsafe impl AbiTransferable for Object {
 
 #[repr(C)]
 pub struct abi_IInspectable {
-    iunknown: crate::com::unknown::abi_IUnknown,
+    iunknown: abi_IUnknown,
 
     pub inspectable_iids:
         unsafe extern "system" fn(NonNullRawComPtr<Object>, *mut u32, *mut *mut Guid) -> ErrorCode,

--- a/src/param.rs
+++ b/src/param.rs
@@ -1,4 +1,4 @@
-use crate::*;
+use crate::{AbiTransferable, HString};
 
 /// A WinRT method parameter used to accept either a reference or value.
 pub enum Param<'a, T: AbiTransferable> {


### PR DESCRIPTION
Fixes #186

Hidden all docs but those that should be used by developers calling WinRT APIs. Moved `TryInto` under the `com` module as it's also COM-specific. Also cleaned up internal structure of public APIs a little. 

We'll eventually provide a comprehensive COM interop story (probably working with com-rs) but for now I'd like to avoid advertising the COM interop support in Rust/WinRT until that's settled. 