### PR TITLE
Publish api docs to GitHub Pages

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -1,0 +1,33 @@
+name: Publish API Docs
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  api-docs:
+    name: Publish API Docs to GitHub Pages
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: doc
+          args: --all --verbose
+        env:
+          RUSTDOCFLAGS: "--cfg=docsrs"
+      - name: Redirect top-level GitHub Pages
+        run: "echo '<meta http-equiv=\"refresh\" content=\"0; url=winrt/index.html\" />' > target/doc/index.html"
+        shell: bash
+      - name: GitHub Pages
+        uses: crazy-max/ghaction-github-pages@v1
+        with:
+          build_dir: target/doc
+        env:
+          GITHUB_PAT: ${{ secrets.GH_PAGES_ACCESS_TOKEN  }}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 ## The Rust/WinRT language projection
 
+([API Docs](https://microsoft.github.io/winrt-rs))
+
 Rust/WinRT follows in the tradition established by [C++/WinRT](https://github.com/microsoft/cppwinrt) of building language projections for the Windows Runtime using standard languages and compilers, providing a natural and idiomatic way for Rust developers to call Windows APIs. Rust/WinRT lets you call any WinRT API past, present, and future using code generated on the fly directly from the metadata describing the API and right into your Rust package where you can call them as if they were just another Rust module.
 
 The Windows Runtime is based on Component Object Model (COM) APIs under the hood and is designed to be accessed through language projections like C++/WinRT and Rust/WinRT. Those language projections take the metadata describing various APIs and provide natural bindings for the target programming language. As you can imagine, this allows developers to more easily build apps and components for Windows using their desired language. You can then use those Windows APIs to build desktop apps, store apps, or something more unique like a component, NT service, or device driver.


### PR DESCRIPTION
Usually when you are looking into a library the first thing to do is check out the API docs. The `winrt` crate isn't published on *crates.io* so you can't look at *docs.rs*, it'd be nice if we published API docs to GitHub Pages instead of making users clone and build the repo locally.

This adds a new GitHub Action that runs `cargo doc` and pushes the generated docs to GitHub Pages.

It's originally based on [the *Generate API Docs* job](https://github.com/Michael-F-Bryan/thumbnails/blob/2fede6d1b51f6a8ae686ece52dc51cdfbcae1f2d/.github/workflows/api-docs.yml) for my `thumbnails` project (which in turn came from [my Rust project template](https://github.com/Michael-F-Bryan/github-template/blob/20bd3930401879d8832b29a60ffc2618edcee74b/.github/workflows/main.yml#L37-L69)).

To wire this up, somewhere with owner rights will need to [create a Personal Access Token](https://github.com/settings/tokens/new ) with the `public_repo` scope then [create a `GH_PAGES_ACCESS_TOKEN` secret](https://github.com/microsoft/winrt-rs/settings/secrets) with the token.