### PR TITLE
Improved tokenization and caching

### DIFF
--- a/crates/gen/src/type_reader.rs
+++ b/crates/gen/src/type_reader.rs
@@ -3,7 +3,6 @@ use crate::codes::Decode;
 use crate::file::{TableIndex, View, WinmdFile};
 use crate::row::Row;
 use crate::tables::TypeDef;
-use crate::types::Type;
 
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
@@ -83,15 +82,6 @@ impl TypeReader {
         }
 
         panic!("Could not find type `{}.{}`", namespace, type_name);
-    }
-
-    pub fn resolve_type(&self, (namespace, type_name): (&str, &str)) -> Type {
-        Type::from_type_def(self, self.resolve_type_def((namespace, type_name)))
-    }
-
-    /// Resolve a type's definition ([`TypeDef`]) to a [`Type`]
-    pub fn type_info(&self, def: TypeDef) -> Type {
-        Type::from_type_def(self, def)
     }
 
     /// Read a [`u32`] value from a specific [`Row`] and column

--- a/crates/gen/src/types/async_get.rs
+++ b/crates/gen/src/types/async_get.rs
@@ -47,7 +47,7 @@ fn to_async_get_tokens(kind: AsyncKind, name: &TypeName, calling_namespace: &str
 
     let return_type = match kind {
         AsyncKind::Operation | AsyncKind::OperationWithProgress => {
-            name.generics[0].to_tokens(calling_namespace)
+            name.generics[0].to_tokens()
         }
         _ => quote! { () },
     };

--- a/crates/gen/src/types/async_get.rs
+++ b/crates/gen/src/types/async_get.rs
@@ -46,9 +46,7 @@ fn to_async_get_tokens(kind: AsyncKind, name: &TypeName, calling_namespace: &str
     let namespace = to_namespace_tokens("Windows.Foundation", calling_namespace);
 
     let return_type = match kind {
-        AsyncKind::Operation | AsyncKind::OperationWithProgress => {
-            name.generics[0].to_tokens()
-        }
+        AsyncKind::Operation | AsyncKind::OperationWithProgress => name.generics[0].to_tokens(),
         _ => quote! { () },
     };
 

--- a/crates/gen/src/types/class.rs
+++ b/crates/gen/src/types/class.rs
@@ -114,7 +114,7 @@ impl Class {
             let signature = &self.signature;
 
             let default_name = &self.interfaces[0].name.tokens;
-            let abi_name = self.interfaces[0].name.to_abi_tokens(&self.name.namespace);
+            let abi_name = self.interfaces[0].name.to_abi_tokens();
             let async_get = async_get_tokens(&self.name, &self.interfaces);
             let debug = debug::debug_tokens(&self.name, &self.interfaces);
 

--- a/crates/gen/src/types/class.rs
+++ b/crates/gen/src/types/class.rs
@@ -52,7 +52,7 @@ impl Class {
                     let mut interface = RequiredInterface::from_type_def(
                         reader,
                         attribute_factory(reader, attribute).unwrap(),
-                        &name.namespace
+                        &name.namespace,
                     );
                     interface.kind = InterfaceKind::Statics;
                     interfaces.push(interface);
@@ -60,7 +60,8 @@ impl Class {
                 ("Windows.Foundation.Metadata", "ActivatableAttribute") => {
                     match attribute_factory(reader, attribute) {
                         Some(def) => {
-                            let mut interface = RequiredInterface::from_type_def(reader, def, &name.namespace);
+                            let mut interface =
+                                RequiredInterface::from_type_def(reader, def, &name.namespace);
                             interface.kind = InterfaceKind::Statics;
                             interfaces.push(interface);
                         }
@@ -91,12 +92,14 @@ impl Class {
     pub fn to_tokens(&self) -> TokenStream {
         let name = &self.name.tokens;
         let type_name = self.type_name(&name);
-        let methods = to_method_tokens( &self.interfaces);
+        let methods = to_method_tokens(&self.interfaces);
 
         if self.interfaces[0].kind == InterfaceKind::Default {
-            let conversions = TokenStream::from_iter(self.interfaces.iter().map(|interface| {
-                interface.to_conversions_tokens( &name, &TokenStream::new())
-            }));
+            let conversions = TokenStream::from_iter(
+                self.interfaces
+                    .iter()
+                    .map(|interface| interface.to_conversions_tokens(&name, &TokenStream::new())),
+            );
 
             let new = if self.default_constructor {
                 quote! {
@@ -163,10 +166,7 @@ impl Class {
         }
     }
 
-    pub fn to_base_conversions_tokens(
-        &self,
-        from: &TokenStream,
-    ) -> TokenStream {
+    pub fn to_base_conversions_tokens(&self, from: &TokenStream) -> TokenStream {
         TokenStream::from_iter(self.bases.iter().map(|base| {
             let into = &base.tokens;
             quote! {

--- a/crates/gen/src/types/class.rs
+++ b/crates/gen/src/types/class.rs
@@ -92,7 +92,7 @@ impl Class {
     }
 
     pub fn to_tokens(&self) -> TokenStream {
-        let name = &*self.name.to_tokens(&self.name.namespace);
+        let name = self.name.to_tokens(&self.name.namespace);
         let type_name = self.type_name(&name);
         let methods = to_method_tokens(&self.name.namespace, &self.interfaces);
 
@@ -116,7 +116,7 @@ impl Class {
             let iterator = iterator_tokens(&self.name, &self.interfaces);
             let signature = &self.signature;
 
-            let default_name = &*self.interfaces[0].name.to_tokens(&self.name.namespace);
+            let default_name = self.interfaces[0].name.to_tokens(&self.name.namespace);
             let abi_name = self.interfaces[0].name.to_abi_tokens(&self.name.namespace);
             let async_get = async_get_tokens(&self.name, &self.interfaces);
             let debug = debug::debug_tokens(&self.name, &self.interfaces);
@@ -172,7 +172,7 @@ impl Class {
         from: &TokenStream,
     ) -> TokenStream {
         TokenStream::from_iter(self.bases.iter().map(|base| {
-            let into = &*base.to_tokens(calling_namespace);
+            let into = base.to_tokens(calling_namespace);
             quote! {
                 impl ::std::convert::From<#from> for #into {
                     fn from(value: #from) -> #into {

--- a/crates/gen/src/types/class.rs
+++ b/crates/gen/src/types/class.rs
@@ -89,7 +89,7 @@ impl Class {
     }
 
     pub fn to_tokens(&self) -> TokenStream {
-        let name = self.name.to_tokens(&self.name.namespace);
+        let name = &self.name.tokens;
         let type_name = self.type_name(&name);
         let methods = to_method_tokens(&self.name.namespace, &self.interfaces);
 
@@ -113,7 +113,7 @@ impl Class {
             let iterator = iterator_tokens(&self.name, &self.interfaces);
             let signature = &self.signature;
 
-            let default_name = self.interfaces[0].name.to_tokens(&self.name.namespace);
+            let default_name = &self.interfaces[0].name.tokens;
             let abi_name = self.interfaces[0].name.to_abi_tokens(&self.name.namespace);
             let async_get = async_get_tokens(&self.name, &self.interfaces);
             let debug = debug::debug_tokens(&self.name, &self.interfaces);
@@ -169,7 +169,7 @@ impl Class {
         from: &TokenStream,
     ) -> TokenStream {
         TokenStream::from_iter(self.bases.iter().map(|base| {
-            let into = base.to_tokens(calling_namespace);
+            let into = &base.tokens;
             quote! {
                 impl ::std::convert::From<#from> for #into {
                     fn from(value: #from) -> #into {

--- a/crates/gen/src/types/class.rs
+++ b/crates/gen/src/types/class.rs
@@ -91,11 +91,11 @@ impl Class {
     pub fn to_tokens(&self) -> TokenStream {
         let name = &self.name.tokens;
         let type_name = self.type_name(&name);
-        let methods = to_method_tokens(&self.name.namespace, &self.interfaces);
+        let methods = to_method_tokens( &self.interfaces);
 
         if self.interfaces[0].kind == InterfaceKind::Default {
             let conversions = TokenStream::from_iter(self.interfaces.iter().map(|interface| {
-                interface.to_conversions_tokens(&self.name.namespace, &name, &TokenStream::new())
+                interface.to_conversions_tokens( &name, &TokenStream::new())
             }));
 
             let new = if self.default_constructor {
@@ -109,7 +109,7 @@ impl Class {
             };
 
             let object = to_object_tokens(&name, &TokenStream::new());
-            let bases = self.to_base_conversions_tokens(&self.name.namespace, &name);
+            let bases = self.to_base_conversions_tokens(&name);
             let iterator = iterator_tokens(&self.name, &self.interfaces);
             let signature = &self.signature;
 
@@ -165,7 +165,6 @@ impl Class {
 
     pub fn to_base_conversions_tokens(
         &self,
-        calling_namespace: &str,
         from: &TokenStream,
     ) -> TokenStream {
         TokenStream::from_iter(self.bases.iter().map(|base| {

--- a/crates/gen/src/types/class.rs
+++ b/crates/gen/src/types/class.rs
@@ -40,7 +40,7 @@ impl Class {
             base = reader.resolve_type_def((base_namespace, base_name));
             let base = TypeName::from_type_def(reader, base, &name.namespace);
 
-            RequiredInterface::append_required(reader, &base, &mut interfaces);
+            RequiredInterface::append_required(reader, &base, &name.namespace, &mut interfaces);
             bases.push(base);
         }
 

--- a/crates/gen/src/types/class.rs
+++ b/crates/gen/src/types/class.rs
@@ -38,11 +38,7 @@ impl Class {
             }
 
             base = reader.resolve_type_def((base_namespace, base_name));
-            let base_namespace = base_namespace.to_string();
-            let base_name = base_name.to_string();
-            let generics = Vec::new();
-
-            let base = TypeName::new(base_namespace, base_name, generics, base);
+            let base = TypeName::from_type_def(reader, base, &name.namespace);
 
             RequiredInterface::append_required(reader, &base, &mut interfaces);
             bases.push(base);
@@ -56,6 +52,7 @@ impl Class {
                     let mut interface = RequiredInterface::from_type_def(
                         reader,
                         attribute_factory(reader, attribute).unwrap(),
+                        &name.namespace
                     );
                     interface.kind = InterfaceKind::Statics;
                     interfaces.push(interface);
@@ -63,7 +60,7 @@ impl Class {
                 ("Windows.Foundation.Metadata", "ActivatableAttribute") => {
                     match attribute_factory(reader, attribute) {
                         Some(def) => {
-                            let mut interface = RequiredInterface::from_type_def(reader, def);
+                            let mut interface = RequiredInterface::from_type_def(reader, def, &name.namespace);
                             interface.kind = InterfaceKind::Statics;
                             interfaces.push(interface);
                         }

--- a/crates/gen/src/types/debug.rs
+++ b/crates/gen/src/types/debug.rs
@@ -53,7 +53,7 @@ pub fn default_debug_tokens(type_name: &TypeName) -> TokenStream {
 
 fn to_tokens(type_name: &TypeName, implementation: &TokenStream) -> TokenStream {
     let constraints = &type_name.constraints;
-    let name = type_name.to_tokens(&type_name.namespace);
+    let name = &type_name.tokens;
     quote! {
         impl<#constraints> ::std::fmt::Debug for #name {
             fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {

--- a/crates/gen/src/types/debug.rs
+++ b/crates/gen/src/types/debug.rs
@@ -52,7 +52,7 @@ pub fn default_debug_tokens(type_name: &TypeName) -> TokenStream {
 }
 
 fn to_tokens(type_name: &TypeName, implementation: &TokenStream) -> TokenStream {
-    let constraints = &*type_name.constraints();
+    let constraints = &type_name.constraints;
     let name = type_name.to_tokens(&type_name.namespace);
     quote! {
         impl<#constraints> ::std::fmt::Debug for #name {

--- a/crates/gen/src/types/debug.rs
+++ b/crates/gen/src/types/debug.rs
@@ -53,7 +53,7 @@ pub fn default_debug_tokens(type_name: &TypeName) -> TokenStream {
 
 fn to_tokens(type_name: &TypeName, implementation: &TokenStream) -> TokenStream {
     let constraints = &*type_name.constraints();
-    let name = &*type_name.to_tokens(&type_name.namespace);
+    let name = type_name.to_tokens(&type_name.namespace);
     quote! {
         impl<#constraints> ::std::fmt::Debug for #name {
             fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {

--- a/crates/gen/src/types/delegate.rs
+++ b/crates/gen/src/types/delegate.rs
@@ -20,7 +20,7 @@ impl Delegate {
             .methods(reader)
             .find(|method| method.name(reader) == "Invoke")
             .unwrap();
-        let method = Method::from_method_def(reader, method, &name.generics);
+        let method = Method::from_method_def(reader, method, &name.generics, &name.namespace);
         let guid = TypeGuid::from_type_def(reader, name.def);
         let signature = name.base_delegate_signature(reader);
         Self {
@@ -44,7 +44,7 @@ impl Delegate {
         let abi_name = self.name.to_abi_tokens(&self.name.namespace);
         let impl_name = self.to_impl_name_tokens();
         let phantoms = self.name.phantoms();
-        let constraints = &*self.name.constraints();
+        let constraints = &self.name.constraints;
         let method = self.method.to_default_tokens(&self.name.namespace);
         let abi_method = self.method.to_abi_tokens(&self.name, &self.name.namespace);
         let guid = self.name.to_guid_tokens(&self.guid);

--- a/crates/gen/src/types/delegate.rs
+++ b/crates/gen/src/types/delegate.rs
@@ -15,14 +15,13 @@ pub struct Delegate {
 }
 
 impl Delegate {
-    pub fn from_type_def(reader: &TypeReader, def: TypeDef) -> Self {
-        let name = TypeName::from_type_def(reader, def);
-        let method = def
+    pub fn from_type_name(reader: &TypeReader, name: TypeName) -> Self {
+        let method = name.def
             .methods(reader)
             .find(|method| method.name(reader) == "Invoke")
             .unwrap();
         let method = Method::from_method_def(reader, method, &name.generics);
-        let guid = TypeGuid::from_type_def(reader, def);
+        let guid = TypeGuid::from_type_def(reader, name.def);
         let signature = name.base_delegate_signature(reader);
         Self {
             name,

--- a/crates/gen/src/types/delegate.rs
+++ b/crates/gen/src/types/delegate.rs
@@ -16,7 +16,8 @@ pub struct Delegate {
 
 impl Delegate {
     pub fn from_type_name(reader: &TypeReader, name: TypeName) -> Self {
-        let method = name.def
+        let method = name
+            .def
             .methods(reader)
             .find(|method| method.name(reader) == "Invoke")
             .unwrap();
@@ -49,9 +50,7 @@ impl Delegate {
         let abi_method = self.method.to_abi_tokens(&self.name);
         let guid = self.name.to_guid_tokens(&self.guid);
         let signature = self.name.to_signature_tokens(&self.signature);
-        let invoke_sig = self
-            .method
-            .to_abi_impl_tokens(&self.name);
+        let invoke_sig = self.method.to_abi_impl_tokens(&self.name);
         let invoke_args = self
             .method
             .params
@@ -196,11 +195,7 @@ impl Delegate {
     }
 
     fn to_fn_constraint_tokens(&self) -> TokenStream {
-        let params = self
-            .method
-            .params
-            .iter()
-            .map(|param| param.to_fn_tokens());
+        let params = self.method.params.iter().map(|param| param.to_fn_tokens());
 
         let return_type = if let Some(return_type) = &self.method.return_type {
             return_type.to_return_tokens()
@@ -217,11 +212,7 @@ impl Delegate {
             quote! { #name<#fn_constraint> }
         } else {
             let name = format_impl_ident(&self.name.name[..self.name.name.len() - 2]);
-            let generics = self
-                .name
-                .generics
-                .iter()
-                .map(|g| g.to_tokens());
+            let generics = self.name.generics.iter().map(|g| g.to_tokens());
             quote! { #name<#(#generics,)* #fn_constraint> }
         }
     }
@@ -232,11 +223,7 @@ impl Delegate {
             quote! { #name::<F> }
         } else {
             let name = format_impl_ident(&self.name.name[..self.name.name.len() - 2]);
-            let generics = self
-                .name
-                .generics
-                .iter()
-                .map(|g| g.to_tokens());
+            let generics = self.name.generics.iter().map(|g| g.to_tokens());
             quote! { #name::<#(#generics,)* F> }
         }
     }

--- a/crates/gen/src/types/delegate.rs
+++ b/crates/gen/src/types/delegate.rs
@@ -40,7 +40,7 @@ impl Delegate {
         let abi_definition = self.name.to_abi_definition_tokens(&self.name.namespace);
         let fn_constraint = self.to_fn_constraint_tokens();
         let impl_definition = self.to_impl_definition_tokens(&fn_constraint);
-        let name = &*self.name.to_tokens(&self.name.namespace);
+        let name = self.name.to_tokens(&self.name.namespace);
         let abi_name = self.name.to_abi_tokens(&self.name.namespace);
         let impl_name = self.to_impl_name_tokens();
         let phantoms = self.name.phantoms();

--- a/crates/gen/src/types/delegate.rs
+++ b/crates/gen/src/types/delegate.rs
@@ -40,7 +40,7 @@ impl Delegate {
         let abi_definition = self.name.to_abi_definition_tokens(&self.name.namespace);
         let fn_constraint = self.to_fn_constraint_tokens();
         let impl_definition = self.to_impl_definition_tokens(&fn_constraint);
-        let name = self.name.to_tokens(&self.name.namespace);
+        let name = &self.name.tokens;
         let abi_name = self.name.to_abi_tokens(&self.name.namespace);
         let impl_name = self.to_impl_name_tokens();
         let phantoms = self.name.phantoms();

--- a/crates/gen/src/types/delegate.rs
+++ b/crates/gen/src/types/delegate.rs
@@ -36,12 +36,12 @@ impl Delegate {
     }
 
     pub fn to_tokens(&self) -> TokenStream {
-        let definition = self.name.to_definition_tokens(&self.name.namespace);
-        let abi_definition = self.name.to_abi_definition_tokens(&self.name.namespace);
+        let definition = self.name.to_definition_tokens();
+        let abi_definition = self.name.to_abi_definition_tokens();
         let fn_constraint = self.to_fn_constraint_tokens();
         let impl_definition = self.to_impl_definition_tokens(&fn_constraint);
         let name = &self.name.tokens;
-        let abi_name = self.name.to_abi_tokens(&self.name.namespace);
+        let abi_name = self.name.to_abi_tokens();
         let impl_name = self.to_impl_name_tokens();
         let phantoms = self.name.phantoms();
         let constraints = &self.name.constraints;

--- a/crates/gen/src/types/delegate.rs
+++ b/crates/gen/src/types/delegate.rs
@@ -45,13 +45,13 @@ impl Delegate {
         let impl_name = self.to_impl_name_tokens();
         let phantoms = self.name.phantoms();
         let constraints = &self.name.constraints;
-        let method = self.method.to_default_tokens(&self.name.namespace);
-        let abi_method = self.method.to_abi_tokens(&self.name, &self.name.namespace);
+        let method = self.method.to_default_tokens();
+        let abi_method = self.method.to_abi_tokens(&self.name);
         let guid = self.name.to_guid_tokens(&self.guid);
         let signature = self.name.to_signature_tokens(&self.signature);
         let invoke_sig = self
             .method
-            .to_abi_impl_tokens(&self.name, &self.name.namespace);
+            .to_abi_impl_tokens(&self.name);
         let invoke_args = self
             .method
             .params
@@ -200,10 +200,10 @@ impl Delegate {
             .method
             .params
             .iter()
-            .map(|param| param.to_fn_tokens(&self.name.namespace));
+            .map(|param| param.to_fn_tokens());
 
         let return_type = if let Some(return_type) = &self.method.return_type {
-            return_type.to_return_tokens(&self.name.namespace)
+            return_type.to_return_tokens()
         } else {
             quote! { () }
         };
@@ -221,7 +221,7 @@ impl Delegate {
                 .name
                 .generics
                 .iter()
-                .map(|g| g.to_tokens(&self.name.namespace));
+                .map(|g| g.to_tokens());
             quote! { #name<#(#generics,)* #fn_constraint> }
         }
     }
@@ -236,7 +236,7 @@ impl Delegate {
                 .name
                 .generics
                 .iter()
-                .map(|g| g.to_tokens(&self.name.namespace));
+                .map(|g| g.to_tokens());
             quote! { #name::<#(#generics,)* F> }
         }
     }

--- a/crates/gen/src/types/enum.rs
+++ b/crates/gen/src/types/enum.rs
@@ -45,7 +45,7 @@ impl Enum {
     }
 
     pub fn to_tokens(&self) -> TokenStream {
-        let name = &*self.name.to_tokens(&self.name.namespace);
+        let name = self.name.to_tokens(&self.name.namespace);
         let signature = &self.signature;
 
         let repr = match self.fields[0].1 {

--- a/crates/gen/src/types/enum.rs
+++ b/crates/gen/src/types/enum.rs
@@ -1,4 +1,3 @@
-use crate::tables::*;
 use crate::types::*;
 use crate::{format_ident, TypeReader};
 
@@ -19,12 +18,11 @@ pub enum EnumConstant {
 }
 
 impl Enum {
-    pub fn from_type_def(reader: &TypeReader, def: TypeDef) -> Self {
-        let name = TypeName::from_type_def(reader, def);
+    pub fn from_type_name(reader: &TypeReader, name: TypeName) -> Self {
         let signature = name.enum_signature(reader);
         let mut fields = Vec::new();
 
-        for field in def.fields(reader) {
+        for field in name.def.fields(reader) {
             for constant in field.constants(reader) {
                 let name = field.name(reader).to_string();
                 let mut value = constant.value(reader);

--- a/crates/gen/src/types/enum.rs
+++ b/crates/gen/src/types/enum.rs
@@ -45,7 +45,7 @@ impl Enum {
     }
 
     pub fn to_tokens(&self) -> TokenStream {
-        let name = self.name.to_tokens(&self.name.namespace);
+        let name = &self.name.tokens;
         let signature = &self.signature;
 
         let repr = match self.fields[0].1 {

--- a/crates/gen/src/types/interface.rs
+++ b/crates/gen/src/types/interface.rs
@@ -20,7 +20,7 @@ impl Interface {
 
         // Ensures that the default interface is first in line.
         let mut default_interface =
-            RequiredInterface::from_type_def(reader, name.def, &name.namespace); // TODO: RequiredInterface::from_type_name
+            RequiredInterface::from_type_def(reader, name.def, &name.namespace);
         default_interface.kind = InterfaceKind::Default;
         interfaces.push(default_interface);
 

--- a/crates/gen/src/types/interface.rs
+++ b/crates/gen/src/types/interface.rs
@@ -24,7 +24,7 @@ impl Interface {
         default_interface.kind = InterfaceKind::Default;
         interfaces.push(default_interface);
 
-        RequiredInterface::append_required(reader, &name, &mut interfaces);
+        RequiredInterface::append_required(reader, &name, &name.namespace, &mut interfaces);
         let signature = name.base_interface_signature(reader);
 
         Self {

--- a/crates/gen/src/types/interface.rs
+++ b/crates/gen/src/types/interface.rs
@@ -19,7 +19,7 @@ impl Interface {
         let mut interfaces = Vec::new();
 
         // Ensures that the default interface is first in line.
-        let mut default_interface = RequiredInterface::from_type_def(reader, name.def);
+        let mut default_interface = RequiredInterface::from_type_def(reader, name.def, &name.namespace); // TODO: RequiredInterface::from_type_name
         default_interface.kind = InterfaceKind::Default;
         interfaces.push(default_interface);
 
@@ -54,7 +54,7 @@ impl Interface {
         let abi_definition = self.name.to_abi_definition_tokens(&self.name.namespace);
         let name = self.name.to_tokens(&self.name.namespace);
         let phantoms = self.name.phantoms();
-        let constraints = &*self.name.constraints();
+        let constraints = &self.name.constraints;
         let default_interface = &self.interfaces[0];
         debug_assert!(default_interface.kind == InterfaceKind::Default);
         let guid = self.name.to_guid_tokens(&default_interface.guid);

--- a/crates/gen/src/types/interface.rs
+++ b/crates/gen/src/types/interface.rs
@@ -19,7 +19,8 @@ impl Interface {
         let mut interfaces = Vec::new();
 
         // Ensures that the default interface is first in line.
-        let mut default_interface = RequiredInterface::from_type_def(reader, name.def, &name.namespace); // TODO: RequiredInterface::from_type_name
+        let mut default_interface =
+            RequiredInterface::from_type_def(reader, name.def, &name.namespace); // TODO: RequiredInterface::from_type_name
         default_interface.kind = InterfaceKind::Default;
         interfaces.push(default_interface);
 
@@ -58,9 +59,12 @@ impl Interface {
         let default_interface = &self.interfaces[0];
         debug_assert!(default_interface.kind == InterfaceKind::Default);
         let guid = self.name.to_guid_tokens(&default_interface.guid);
-        let conversions = TokenStream::from_iter(self.interfaces.iter().skip(1).map(|interface| {
-            interface.to_conversions_tokens(&name, &constraints)
-        }));
+        let conversions = TokenStream::from_iter(
+            self.interfaces
+                .iter()
+                .skip(1)
+                .map(|interface| interface.to_conversions_tokens(&name, &constraints)),
+        );
 
         let object = to_object_tokens(&name, &constraints);
         let methods = to_method_tokens(&self.interfaces);

--- a/crates/gen/src/types/interface.rs
+++ b/crates/gen/src/types/interface.rs
@@ -139,7 +139,6 @@ impl Interface {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/gen/src/types/interface.rs
+++ b/crates/gen/src/types/interface.rs
@@ -52,7 +52,7 @@ impl Interface {
     pub fn to_tokens(&self) -> TokenStream {
         let definition = self.name.to_definition_tokens(&self.name.namespace);
         let abi_definition = self.name.to_abi_definition_tokens(&self.name.namespace);
-        let name = self.name.to_tokens(&self.name.namespace);
+        let name = &self.name.tokens;
         let phantoms = self.name.phantoms();
         let constraints = &self.name.constraints;
         let default_interface = &self.interfaces[0];

--- a/crates/gen/src/types/interface.rs
+++ b/crates/gen/src/types/interface.rs
@@ -50,8 +50,8 @@ impl Interface {
     }
 
     pub fn to_tokens(&self) -> TokenStream {
-        let definition = self.name.to_definition_tokens(&self.name.namespace);
-        let abi_definition = self.name.to_abi_definition_tokens(&self.name.namespace);
+        let definition = self.name.to_definition_tokens();
+        let abi_definition = self.name.to_abi_definition_tokens();
         let name = &self.name.tokens;
         let phantoms = self.name.phantoms();
         let constraints = &self.name.constraints;

--- a/crates/gen/src/types/interface.rs
+++ b/crates/gen/src/types/interface.rs
@@ -15,12 +15,11 @@ pub struct Interface {
 }
 
 impl Interface {
-    pub fn from_type_def(reader: &TypeReader, def: TypeDef) -> Self {
-        let name = TypeName::from_type_def(reader, def);
+    pub fn from_type_name(reader: &TypeReader, name: TypeName) -> Self {
         let mut interfaces = Vec::new();
 
         // Ensures that the default interface is first in line.
-        let mut default_interface = RequiredInterface::from_type_def(reader, def);
+        let mut default_interface = RequiredInterface::from_type_def(reader, name.def);
         default_interface.kind = InterfaceKind::Default;
         interfaces.push(default_interface);
 
@@ -133,103 +132,5 @@ impl Interface {
             #object
             #iterator
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn interface((namespace, type_name): (&str, &str)) -> Interface {
-        let reader = &TypeReader::from_os();
-        let t = reader.resolve_type((namespace, type_name));
-
-        match t {
-            Type::Interface(t) => t,
-            _ => panic!("Type not an interface"),
-        }
-    }
-
-    #[test]
-    fn test_stringable() {
-        let t = interface(("Windows.Foundation", "IStringable"));
-        assert!(t.name.runtime_name() == "Windows.Foundation.IStringable");
-        assert!(t.interfaces.len() == 1);
-        let t = &t.interfaces[0];
-        assert!(t.name.runtime_name() == "Windows.Foundation.IStringable");
-        assert!(t.kind == InterfaceKind::Default);
-
-        assert!(t.methods.len() == 1);
-        let method = &t.methods[0];
-        assert!(method.name == "to_string");
-        assert!(method.kind == MethodKind::Normal);
-
-        assert!(method.params.is_empty());
-        let param = method.return_type.as_ref().unwrap();
-        assert!(param.kind == TypeKind::String);
-
-        assert!(format!("{:#?}", &t.guid) == "96369f54-8eb6-48f0-abce-c1b211e627c3");
-    }
-
-    #[test]
-    fn test_async_action() {
-        let t = interface(("Windows.Foundation", "IAsyncAction"));
-        assert!(t.name.runtime_name() == "Windows.Foundation.IAsyncAction");
-
-        assert!(t.interfaces.len() == 2);
-
-        let interface = t
-            .interfaces
-            .iter()
-            .find(|interface| interface.name.name == "IAsyncInfo")
-            .unwrap();
-
-        assert!(interface.kind == InterfaceKind::NonDefault);
-        assert!(interface.name.runtime_name() == "Windows.Foundation.IAsyncInfo");
-
-        let interface = t
-            .interfaces
-            .iter()
-            .find(|interface| interface.name.name == "IAsyncAction")
-            .unwrap();
-
-        assert!(interface.kind == InterfaceKind::Default);
-        assert!(interface.name.runtime_name() == "Windows.Foundation.IAsyncAction");
-    }
-
-    #[test]
-    fn test_observable_map() {
-        let t = interface(("Windows.Foundation.Collections", "IObservableMap`2"));
-        assert!(t.name.runtime_name() == "Windows.Foundation.Collections.IObservableMap`2<K, V>");
-        assert!(t.interfaces.len() == 3);
-
-        let default_interface = t
-            .interfaces
-            .iter()
-            .find(|required| required.name.name == "IObservableMap`2")
-            .unwrap();
-
-        assert!(default_interface.kind == InterfaceKind::Default);
-        assert!(default_interface.methods.len() == 2);
-        assert!(default_interface.methods[0].name == "map_changed");
-        assert!(default_interface.methods[1].name == "remove_map_changed");
-
-        let map = t
-            .interfaces
-            .iter()
-            .find(|required| required.name.name == "IMap`2")
-            .unwrap();
-
-        assert!(map.kind == InterfaceKind::NonDefault);
-        assert!(map.name.runtime_name() == "Windows.Foundation.Collections.IMap`2<K, V>");
-
-        let iterable = t
-            .interfaces
-            .iter()
-            .find(|required| required.name.name == "IIterable`1")
-            .unwrap();
-
-        assert!(iterable.kind == InterfaceKind::NonDefault);
-        assert!(iterable.name.runtime_name() == "Windows.Foundation.Collections.IIterable`1<Windows.Foundation.Collections.IKeyValuePair`2<K, V>>");
     }
 }

--- a/crates/gen/src/types/interface.rs
+++ b/crates/gen/src/types/interface.rs
@@ -59,12 +59,12 @@ impl Interface {
         debug_assert!(default_interface.kind == InterfaceKind::Default);
         let guid = self.name.to_guid_tokens(&default_interface.guid);
         let conversions = TokenStream::from_iter(self.interfaces.iter().skip(1).map(|interface| {
-            interface.to_conversions_tokens(&self.name.namespace, &name, &constraints)
+            interface.to_conversions_tokens(&name, &constraints)
         }));
 
         let object = to_object_tokens(&name, &constraints);
-        let methods = to_method_tokens(&self.name.namespace, &self.interfaces);
-        let abi_methods = default_interface.to_abi_method_tokens(&default_interface.name.namespace);
+        let methods = to_method_tokens(&self.interfaces);
+        let abi_methods = default_interface.to_abi_method_tokens();
         let iterator = iterator_tokens(&self.name, &self.interfaces);
         let signature = self.name.to_signature_tokens(&self.signature);
         let async_get = async_get_tokens(&self.name, &self.interfaces);

--- a/crates/gen/src/types/interface.rs
+++ b/crates/gen/src/types/interface.rs
@@ -138,3 +138,103 @@ impl Interface {
         }
     }
 }
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn interface((namespace, type_name): (&str, &str)) -> Interface {
+        let reader = &TypeReader::from_os();
+        let t = reader.resolve_type_def((namespace, type_name));
+        let t = Type::from_type_def(reader, t);
+
+        match t {
+            Type::Interface(t) => t,
+            _ => panic!("Type not an interface"),
+        }
+    }
+
+    #[test]
+    fn test_stringable() {
+        let t = interface(("Windows.Foundation", "IStringable"));
+        assert!(t.name.runtime_name() == "Windows.Foundation.IStringable");
+        assert!(t.interfaces.len() == 1);
+        let t = &t.interfaces[0];
+        assert!(t.name.runtime_name() == "Windows.Foundation.IStringable");
+        assert!(t.kind == InterfaceKind::Default);
+
+        assert!(t.methods.len() == 1);
+        let method = &t.methods[0];
+        assert!(method.name == "to_string");
+        assert!(method.kind == MethodKind::Normal);
+
+        assert!(method.params.is_empty());
+        let param = method.return_type.as_ref().unwrap();
+        assert!(param.kind == TypeKind::String);
+
+        assert!(format!("{:#?}", &t.guid) == "96369f54-8eb6-48f0-abce-c1b211e627c3");
+    }
+
+    #[test]
+    fn test_async_action() {
+        let t = interface(("Windows.Foundation", "IAsyncAction"));
+        assert!(t.name.runtime_name() == "Windows.Foundation.IAsyncAction");
+
+        assert!(t.interfaces.len() == 2);
+
+        let interface = t
+            .interfaces
+            .iter()
+            .find(|interface| interface.name.name == "IAsyncInfo")
+            .unwrap();
+
+        assert!(interface.kind == InterfaceKind::NonDefault);
+        assert!(interface.name.runtime_name() == "Windows.Foundation.IAsyncInfo");
+
+        let interface = t
+            .interfaces
+            .iter()
+            .find(|interface| interface.name.name == "IAsyncAction")
+            .unwrap();
+
+        assert!(interface.kind == InterfaceKind::Default);
+        assert!(interface.name.runtime_name() == "Windows.Foundation.IAsyncAction");
+    }
+
+    #[test]
+    fn test_observable_map() {
+        let t = interface(("Windows.Foundation.Collections", "IObservableMap`2"));
+        assert!(t.name.runtime_name() == "Windows.Foundation.Collections.IObservableMap`2<K, V>");
+        assert!(t.interfaces.len() == 3);
+
+        let default_interface = t
+            .interfaces
+            .iter()
+            .find(|required| required.name.name == "IObservableMap`2")
+            .unwrap();
+
+        assert!(default_interface.kind == InterfaceKind::Default);
+        assert!(default_interface.methods.len() == 2);
+        assert!(default_interface.methods[0].name == "map_changed");
+        assert!(default_interface.methods[1].name == "remove_map_changed");
+
+        let map = t
+            .interfaces
+            .iter()
+            .find(|required| required.name.name == "IMap`2")
+            .unwrap();
+
+        assert!(map.kind == InterfaceKind::NonDefault);
+        assert!(map.name.runtime_name() == "Windows.Foundation.Collections.IMap`2<K, V>");
+
+        let iterable = t
+            .interfaces
+            .iter()
+            .find(|required| required.name.name == "IIterable`1")
+            .unwrap();
+
+        assert!(iterable.kind == InterfaceKind::NonDefault);
+        assert!(iterable.name.runtime_name() == "Windows.Foundation.Collections.IIterable`1<Windows.Foundation.Collections.IKeyValuePair`2<K, V>>");
+    }
+}

--- a/crates/gen/src/types/interface.rs
+++ b/crates/gen/src/types/interface.rs
@@ -52,7 +52,7 @@ impl Interface {
     pub fn to_tokens(&self) -> TokenStream {
         let definition = self.name.to_definition_tokens(&self.name.namespace);
         let abi_definition = self.name.to_abi_definition_tokens(&self.name.namespace);
-        let name = &*self.name.to_tokens(&self.name.namespace);
+        let name = self.name.to_tokens(&self.name.namespace);
         let phantoms = self.name.phantoms();
         let constraints = &*self.name.constraints();
         let default_interface = &self.interfaces[0];

--- a/crates/gen/src/types/iterator.rs
+++ b/crates/gen/src/types/iterator.rs
@@ -158,7 +158,7 @@ pub fn iterator_tokens(name: &TypeName, interfaces: &Vec<RequiredInterface>) -> 
         {
             let item = interface.name.generics[0].to_tokens(&name.namespace);
             let wfc = to_namespace_tokens(&interface.name.namespace, &name.namespace);
-            let name = &*name.to_tokens(&name.namespace);
+            let name = name.to_tokens(&name.namespace);
 
             return quote! {
                 impl ::std::iter::IntoIterator for #name {
@@ -185,7 +185,7 @@ pub fn iterator_tokens(name: &TypeName, interfaces: &Vec<RequiredInterface>) -> 
         {
             let item = interface.name.generics[0].to_tokens(&name.namespace);
             let wfc = to_namespace_tokens(&interface.name.namespace, &name.namespace);
-            let name = &*name.to_tokens(&name.namespace);
+            let name = name.to_tokens(&name.namespace);
 
             return quote! {
                 impl ::std::iter::IntoIterator for #name {
@@ -220,7 +220,7 @@ pub fn iterator_tokens(name: &TypeName, interfaces: &Vec<RequiredInterface>) -> 
             let constraints = &*name.constraints();
             let item = interface.name.generics[0].to_tokens(&name.namespace);
             let wfc = to_namespace_tokens(&interface.name.namespace, &name.namespace);
-            let name = &*name.to_tokens(&name.namespace);
+            let name = name.to_tokens(&name.namespace);
 
             quote! {
                impl<#constraints> ::std::iter::IntoIterator for #name {

--- a/crates/gen/src/types/iterator.rs
+++ b/crates/gen/src/types/iterator.rs
@@ -156,7 +156,7 @@ pub fn iterator_tokens(name: &TypeName, interfaces: &Vec<RequiredInterface>) -> 
         if interface.name.name == "IVectorView`1"
             && interface.name.namespace == "Windows.Foundation.Collections"
         {
-            let item = interface.name.generics[0].to_tokens(&name.namespace);
+            let item = interface.name.generics[0].to_tokens();
             let wfc = to_namespace_tokens(&interface.name.namespace, &name.namespace);
             let name = &name.tokens;
 
@@ -183,7 +183,7 @@ pub fn iterator_tokens(name: &TypeName, interfaces: &Vec<RequiredInterface>) -> 
         if interface.name.name == "IVectorView`1"
             && interface.name.namespace == "Windows.Foundation.Collections"
         {
-            let item = interface.name.generics[0].to_tokens(&name.namespace);
+            let item = interface.name.generics[0].to_tokens();
             let wfc = to_namespace_tokens(&interface.name.namespace, &name.namespace);
             let name = &name.tokens;
 
@@ -218,7 +218,7 @@ pub fn iterator_tokens(name: &TypeName, interfaces: &Vec<RequiredInterface>) -> 
         None => quote! {},
         Some(interface) => {
             let constraints = &name.constraints;
-            let item = interface.name.generics[0].to_tokens(&name.namespace);
+            let item = interface.name.generics[0].to_tokens();
             let wfc = to_namespace_tokens(&interface.name.namespace, &name.namespace);
             let name = &name.tokens;
 

--- a/crates/gen/src/types/iterator.rs
+++ b/crates/gen/src/types/iterator.rs
@@ -217,7 +217,7 @@ pub fn iterator_tokens(name: &TypeName, interfaces: &Vec<RequiredInterface>) -> 
     match iterable {
         None => quote! {},
         Some(interface) => {
-            let constraints = &*name.constraints();
+            let constraints = &name.constraints;
             let item = interface.name.generics[0].to_tokens(&name.namespace);
             let wfc = to_namespace_tokens(&interface.name.namespace, &name.namespace);
             let name = name.to_tokens(&name.namespace);

--- a/crates/gen/src/types/iterator.rs
+++ b/crates/gen/src/types/iterator.rs
@@ -158,7 +158,7 @@ pub fn iterator_tokens(name: &TypeName, interfaces: &Vec<RequiredInterface>) -> 
         {
             let item = interface.name.generics[0].to_tokens(&name.namespace);
             let wfc = to_namespace_tokens(&interface.name.namespace, &name.namespace);
-            let name = name.to_tokens(&name.namespace);
+            let name = &name.tokens;
 
             return quote! {
                 impl ::std::iter::IntoIterator for #name {
@@ -185,7 +185,7 @@ pub fn iterator_tokens(name: &TypeName, interfaces: &Vec<RequiredInterface>) -> 
         {
             let item = interface.name.generics[0].to_tokens(&name.namespace);
             let wfc = to_namespace_tokens(&interface.name.namespace, &name.namespace);
-            let name = name.to_tokens(&name.namespace);
+            let name = &name.tokens;
 
             return quote! {
                 impl ::std::iter::IntoIterator for #name {
@@ -220,7 +220,7 @@ pub fn iterator_tokens(name: &TypeName, interfaces: &Vec<RequiredInterface>) -> 
             let constraints = &name.constraints;
             let item = interface.name.generics[0].to_tokens(&name.namespace);
             let wfc = to_namespace_tokens(&interface.name.namespace, &name.namespace);
-            let name = name.to_tokens(&name.namespace);
+            let name = &name.tokens;
 
             quote! {
                impl<#constraints> ::std::iter::IntoIterator for #name {

--- a/crates/gen/src/types/method.rs
+++ b/crates/gen/src/types/method.rs
@@ -30,6 +30,7 @@ impl Method {
         reader: &TypeReader,
         method: MethodDef,
         generics: &Vec<TypeKind>,
+        calling_namespace: &str,
     ) -> Method {
         let (name, kind) = if method.flags(reader).special() {
             let name = method.name(reader);
@@ -68,7 +69,7 @@ impl Method {
         } else {
             let name = "__result".to_owned();
             let array = blob.peek_unsigned().0 == 0x1D;
-            let kind = TypeKind::from_blob(&mut blob, generics);
+            let kind = TypeKind::from_blob(&mut blob, generics, calling_namespace);
             let input = false;
             let by_ref = true;
             Some(Param {
@@ -90,7 +91,7 @@ impl Method {
                 blob.read_modifiers();
                 let by_ref = blob.read_expected(0x10);
                 let array = blob.peek_unsigned().0 == 0x1D;
-                let kind = TypeKind::from_blob(&mut blob, generics);
+                let kind = TypeKind::from_blob(&mut blob, generics, calling_namespace);
 
                 params.push(Param {
                     name,

--- a/crates/gen/src/types/method.rs
+++ b/crates/gen/src/types/method.rs
@@ -134,7 +134,7 @@ impl Method {
     }
 
     pub fn to_abi_tokens(&self, self_name: &TypeName, calling_namespace: &str) -> TokenStream {
-        let type_name = self_name.to_tokens(calling_namespace);
+        let type_name = &self_name.tokens;
         let name = format_ident(&self.name);
         let params = TokenStream::from_iter(
             self.params
@@ -149,7 +149,7 @@ impl Method {
     }
 
     pub fn to_abi_impl_tokens(&self, self_name: &TypeName, calling_namespace: &str) -> TokenStream {
-        let type_name = self_name.to_tokens(calling_namespace);
+        let type_name = &self_name.tokens;
         let name = format_ident(&self.name);
         let params = self
             .params
@@ -259,7 +259,7 @@ impl Method {
         let params = self.to_param_tokens(calling_namespace);
         let constraints = self.to_constraint_tokens(calling_namespace);
         let args = self.to_arg_tokens();
-        let interface = interface.name.to_tokens(calling_namespace);
+        let interface = &interface.name.tokens;
 
         let return_type = if let Some(return_type) = &self.return_type {
             return_type.to_return_tokens(calling_namespace)
@@ -283,7 +283,7 @@ impl Method {
         let params = self.to_param_tokens(calling_namespace);
         let constraints = self.to_constraint_tokens(calling_namespace);
         let args = self.to_arg_tokens();
-        let interface = interface.name.to_tokens(calling_namespace);
+        let interface = &interface.name.tokens;
 
         let return_type = if let Some(return_type) = &self.return_type {
             return_type.to_return_tokens(calling_namespace)

--- a/crates/gen/src/types/method.rs
+++ b/crates/gen/src/types/method.rs
@@ -133,7 +133,7 @@ impl Method {
     }
 
     pub fn to_abi_tokens(&self, self_name: &TypeName, calling_namespace: &str) -> TokenStream {
-        let type_name = &*self_name.to_tokens(calling_namespace);
+        let type_name = self_name.to_tokens(calling_namespace);
         let name = format_ident(&self.name);
         let params = TokenStream::from_iter(
             self.params
@@ -148,7 +148,7 @@ impl Method {
     }
 
     pub fn to_abi_impl_tokens(&self, self_name: &TypeName, calling_namespace: &str) -> TokenStream {
-        let type_name = &*self_name.to_tokens(calling_namespace);
+        let type_name = self_name.to_tokens(calling_namespace);
         let name = format_ident(&self.name);
         let params = self
             .params
@@ -258,7 +258,7 @@ impl Method {
         let params = self.to_param_tokens(calling_namespace);
         let constraints = self.to_constraint_tokens(calling_namespace);
         let args = self.to_arg_tokens();
-        let interface = &*interface.name.to_tokens(calling_namespace);
+        let interface = interface.name.to_tokens(calling_namespace);
 
         let return_type = if let Some(return_type) = &self.return_type {
             return_type.to_return_tokens(calling_namespace)
@@ -282,7 +282,7 @@ impl Method {
         let params = self.to_param_tokens(calling_namespace);
         let constraints = self.to_constraint_tokens(calling_namespace);
         let args = self.to_arg_tokens();
-        let interface = &*interface.name.to_tokens(calling_namespace);
+        let interface = interface.name.to_tokens(calling_namespace);
 
         let return_type = if let Some(return_type) = &self.return_type {
             return_type.to_return_tokens(calling_namespace)

--- a/crates/gen/src/types/method.rs
+++ b/crates/gen/src/types/method.rs
@@ -250,10 +250,7 @@ impl Method {
         }
     }
 
-    pub fn to_non_default_tokens(
-        &self,
-        interface: &RequiredInterface,
-    ) -> TokenStream {
+    pub fn to_non_default_tokens(&self, interface: &RequiredInterface) -> TokenStream {
         let method_name = format_ident(&self.name);
         let params = self.to_param_tokens();
         let constraints = self.to_constraint_tokens();
@@ -273,10 +270,7 @@ impl Method {
         }
     }
 
-    pub fn to_static_tokens(
-        &self,
-        interface: &RequiredInterface,
-    ) -> TokenStream {
+    pub fn to_static_tokens(&self, interface: &RequiredInterface) -> TokenStream {
         let method_name = format_ident(&self.name);
         let params = self.to_param_tokens();
         let constraints = self.to_constraint_tokens();

--- a/crates/gen/src/types/param.rs
+++ b/crates/gen/src/types/param.rs
@@ -13,9 +13,9 @@ pub struct Param {
 }
 
 impl Param {
-    pub fn to_tokens(&self, calling_namespace: &str, position: usize) -> TokenStream {
+    pub fn to_tokens(&self, position: usize) -> TokenStream {
         let name = format_ident(&self.name);
-        let tokens = self.kind.to_tokens(calling_namespace);
+        let tokens = self.kind.to_tokens();
 
         if self.array {
             if self.input {
@@ -45,8 +45,8 @@ impl Param {
         }
     }
 
-    pub fn to_fn_tokens(&self, calling_namespace: &str) -> TokenStream {
-        let tokens = self.kind.to_tokens(calling_namespace);
+    pub fn to_fn_tokens(&self) -> TokenStream {
+        let tokens = self.kind.to_tokens();
 
         if self.array {
             if self.input {
@@ -75,8 +75,8 @@ impl Param {
         }
     }
 
-    pub fn to_return_tokens(&self, calling_namespace: &str) -> TokenStream {
-        let tokens = self.kind.to_tokens(calling_namespace);
+    pub fn to_return_tokens(&self) -> TokenStream {
+        let tokens = self.kind.to_tokens();
 
         if self.array {
             quote! { ::winrt::Array<#tokens> }
@@ -85,8 +85,8 @@ impl Param {
         }
     }
 
-    pub fn to_abi_tokens(&self, calling_namespace: &str) -> TokenStream {
-        let tokens = self.kind.to_abi_tokens(calling_namespace);
+    pub fn to_abi_tokens(&self) -> TokenStream {
+        let tokens = self.kind.to_abi_tokens();
 
         if self.array {
             if self.input {
@@ -103,8 +103,8 @@ impl Param {
         }
     }
 
-    pub fn to_abi_return_arg_tokens(&self, calling_namespace: &str) -> TokenStream {
-        let return_type = self.kind.to_tokens(calling_namespace);
+    pub fn to_abi_return_arg_tokens(&self) -> TokenStream {
+        let return_type = self.kind.to_tokens();
 
         if self.array {
             quote! { ::winrt::Array::<#return_type>::set_abi_len(&mut __ok), winrt::Array::<#return_type>::set_abi(&mut __ok), }

--- a/crates/gen/src/types/required_interface.rs
+++ b/crates/gen/src/types/required_interface.rs
@@ -101,12 +101,13 @@ impl RequiredInterface {
     pub fn append_required(
         reader: &TypeReader,
         name: &TypeName,
+        calling_namespace: &str,
         interfaces: &mut Vec<RequiredInterface>,
     ) {
         let generics = !name.generics.is_empty();
 
         let mut map = RequiredInterfaces::default();
-        map.insert_required(reader, name, &name.namespace);
+        map.insert_required(reader, name, calling_namespace);
 
         for (append_name, kind) in map.0 {
             let mut kind = kind;
@@ -120,7 +121,7 @@ impl RequiredInterface {
                 append_name,
                 kind,
                 generics,
-                &name.namespace,
+                calling_namespace,
             ));
         }
     }

--- a/crates/gen/src/types/required_interface.rs
+++ b/crates/gen/src/types/required_interface.rs
@@ -127,7 +127,7 @@ impl RequiredInterface {
     ) -> TokenStream {
         match self.kind {
             InterfaceKind::Default => {
-                let into = self.name.to_tokens(calling_namespace);
+                let into = &self.name.tokens;
                 quote! {
                     impl<#constraints> ::std::convert::From<#from> for #into {
                         fn from(value: #from) -> #into {
@@ -152,7 +152,7 @@ impl RequiredInterface {
                 }
             }
             InterfaceKind::NonDefault => {
-                let into = self.name.to_tokens(calling_namespace);
+                let into = &self.name.tokens;
                 quote! {
                     impl<#constraints> ::std::convert::From<#from> for #into {
                         fn from(value: #from) -> #into {

--- a/crates/gen/src/types/required_interface.rs
+++ b/crates/gen/src/types/required_interface.rs
@@ -126,7 +126,7 @@ impl RequiredInterface {
     ) -> TokenStream {
         match self.kind {
             InterfaceKind::Default => {
-                let into = &*self.name.to_tokens(calling_namespace);
+                let into = self.name.to_tokens(calling_namespace);
                 quote! {
                     impl<#constraints> ::std::convert::From<#from> for #into {
                         fn from(value: #from) -> #into {
@@ -151,7 +151,7 @@ impl RequiredInterface {
                 }
             }
             InterfaceKind::NonDefault => {
-                let into = &*self.name.to_tokens(calling_namespace);
+                let into = self.name.to_tokens(calling_namespace);
                 quote! {
                     impl<#constraints> ::std::convert::From<#from> for #into {
                         fn from(value: #from) -> #into {

--- a/crates/gen/src/types/required_interface.rs
+++ b/crates/gen/src/types/required_interface.rs
@@ -23,13 +23,15 @@ pub enum InterfaceKind {
 }
 
 impl RequiredInterface {
-    pub fn from_type_def(reader: &TypeReader, def: TypeDef, calling_namespace:&str) -> Self {
+    pub fn from_type_def(reader: &TypeReader, def: TypeDef, calling_namespace: &str) -> Self {
         let name = TypeName::from_type_def(reader, def, calling_namespace);
         let guid = TypeGuid::from_type_def(reader, def);
 
         let mut methods = def
             .methods(reader)
-            .map(|method| Method::from_method_def(reader, method, &name.generics, calling_namespace))
+            .map(|method| {
+                Method::from_method_def(reader, method, &name.generics, calling_namespace)
+            })
             .collect();
 
         rename_collisions(&mut methods);
@@ -47,14 +49,16 @@ impl RequiredInterface {
         name: TypeName,
         kind: InterfaceKind,
         generics: bool,
-        calling_namespace: &str
+        calling_namespace: &str,
     ) -> Self {
         let guid = name.guid(reader, generics);
 
         let mut methods = name
             .def
             .methods(reader)
-            .map(|method| Method::from_method_def(reader, method, &name.generics, calling_namespace))
+            .map(|method| {
+                Method::from_method_def(reader, method, &name.generics, calling_namespace)
+            })
             .collect();
 
         rename_collisions(&mut methods);
@@ -78,7 +82,13 @@ impl RequiredInterface {
         map.insert_required(reader, name, &name.namespace);
 
         for (append_name, kind) in map.0 {
-            let required = RequiredInterface::from_type_name_and_kind(reader, append_name, kind, generics, &name.namespace);
+            let required = RequiredInterface::from_type_name_and_kind(
+                reader,
+                append_name,
+                kind,
+                generics,
+                &name.namespace,
+            );
 
             if kind == InterfaceKind::Default {
                 interfaces.insert(0, required);
@@ -106,7 +116,11 @@ impl RequiredInterface {
             }
 
             interfaces.push(RequiredInterface::from_type_name_and_kind(
-                reader, append_name, kind, generics, &name.namespace
+                reader,
+                append_name,
+                kind,
+                generics,
+                &name.namespace,
             ));
         }
     }
@@ -180,9 +194,7 @@ impl RequiredInterface {
     }
 }
 
-pub fn to_method_tokens(
-    interfaces: &Vec<RequiredInterface>,
-) -> TokenStream {
+pub fn to_method_tokens(interfaces: &Vec<RequiredInterface>) -> TokenStream {
     let mut tokens = Vec::new();
     let mut names = BTreeSet::new();
 

--- a/crates/gen/src/types/required_interface.rs
+++ b/crates/gen/src/types/required_interface.rs
@@ -23,13 +23,13 @@ pub enum InterfaceKind {
 }
 
 impl RequiredInterface {
-    pub fn from_type_def(reader: &TypeReader, def: TypeDef) -> Self {
-        let name = TypeName::from_type_def(reader, def);
+    pub fn from_type_def(reader: &TypeReader, def: TypeDef, calling_namespace:&str) -> Self {
+        let name = TypeName::from_type_def(reader, def, calling_namespace);
         let guid = TypeGuid::from_type_def(reader, def);
 
         let mut methods = def
             .methods(reader)
-            .map(|method| Method::from_method_def(reader, method, &name.generics))
+            .map(|method| Method::from_method_def(reader, method, &name.generics, calling_namespace))
             .collect();
 
         rename_collisions(&mut methods);
@@ -47,13 +47,14 @@ impl RequiredInterface {
         name: TypeName,
         kind: InterfaceKind,
         generics: bool,
+        calling_namespace: &str
     ) -> Self {
         let guid = name.guid(reader, generics);
 
         let mut methods = name
             .def
             .methods(reader)
-            .map(|method| Method::from_method_def(reader, method, &name.generics))
+            .map(|method| Method::from_method_def(reader, method, &name.generics, calling_namespace))
             .collect();
 
         rename_collisions(&mut methods);
@@ -74,10 +75,10 @@ impl RequiredInterface {
         let generics = !name.generics.is_empty();
 
         let mut map = RequiredInterfaces::default();
-        map.insert_required(reader, name);
+        map.insert_required(reader, name, &name.namespace);
 
-        for (name, kind) in map.0 {
-            let required = RequiredInterface::from_type_name_and_kind(reader, name, kind, generics);
+        for (append_name, kind) in map.0 {
+            let required = RequiredInterface::from_type_name_and_kind(reader, append_name, kind, generics, &name.namespace);
 
             if kind == InterfaceKind::Default {
                 interfaces.insert(0, required);
@@ -95,9 +96,9 @@ impl RequiredInterface {
         let generics = !name.generics.is_empty();
 
         let mut map = RequiredInterfaces::default();
-        map.insert_required(reader, name);
+        map.insert_required(reader, name, &name.namespace);
 
-        for (name, kind) in map.0 {
+        for (append_name, kind) in map.0 {
             let mut kind = kind;
 
             if kind == InterfaceKind::Default {
@@ -105,7 +106,7 @@ impl RequiredInterface {
             }
 
             interfaces.push(RequiredInterface::from_type_name_and_kind(
-                reader, name, kind, generics,
+                reader, append_name, kind, generics, &name.namespace
             ));
         }
     }

--- a/crates/gen/src/types/required_interface.rs
+++ b/crates/gen/src/types/required_interface.rs
@@ -111,17 +111,16 @@ impl RequiredInterface {
         }
     }
 
-    pub fn to_abi_method_tokens(&self, calling_namespace: &str) -> TokenStream {
+    pub fn to_abi_method_tokens(&self) -> TokenStream {
         TokenStream::from_iter(
             self.methods
                 .iter()
-                .map(|method| method.to_abi_tokens(&self.name, calling_namespace)),
+                .map(|method| method.to_abi_tokens(&self.name)),
         )
     }
 
     pub fn to_conversions_tokens(
         &self,
-        calling_namespace: &str,
         from: &TokenStream,
         constraints: &TokenStream,
     ) -> TokenStream {
@@ -182,7 +181,6 @@ impl RequiredInterface {
 }
 
 pub fn to_method_tokens(
-    calling_namespace: &str,
     interfaces: &Vec<RequiredInterface>,
 ) -> TokenStream {
     let mut tokens = Vec::new();
@@ -198,11 +196,11 @@ pub fn to_method_tokens(
             names.insert(&method.name);
 
             tokens.push(match interface.kind {
-                InterfaceKind::Default => method.to_default_tokens(calling_namespace),
+                InterfaceKind::Default => method.to_default_tokens(),
                 InterfaceKind::NonDefault | InterfaceKind::Overrides => {
-                    method.to_non_default_tokens(calling_namespace, interface)
+                    method.to_non_default_tokens(interface)
                 }
-                InterfaceKind::Statics => method.to_static_tokens(calling_namespace, interface),
+                InterfaceKind::Statics => method.to_static_tokens(interface),
             });
         }
     }

--- a/crates/gen/src/types/required_interfaces.rs
+++ b/crates/gen/src/types/required_interfaces.rs
@@ -7,7 +7,13 @@ use std::collections::*;
 pub struct RequiredInterfaces(pub BTreeMap<TypeName, InterfaceKind>);
 
 impl RequiredInterfaces {
-    fn insert_type_name(&mut self, reader: &TypeReader, name: TypeName, kind: InterfaceKind, calling_namespace:&str) {
+    fn insert_type_name(
+        &mut self,
+        reader: &TypeReader,
+        name: TypeName,
+        kind: InterfaceKind,
+        calling_namespace: &str,
+    ) {
         if !self.0.contains_key(&name) {
             self.insert_required(reader, &name, calling_namespace);
             self.0.insert(name, kind);
@@ -16,10 +22,19 @@ impl RequiredInterfaces {
         }
     }
 
-    pub fn insert_required(&mut self, reader: &TypeReader, name: &TypeName, calling_namespace:&str) {
+    pub fn insert_required(
+        &mut self,
+        reader: &TypeReader,
+        name: &TypeName,
+        calling_namespace: &str,
+    ) {
         for required in name.def.interfaces(reader) {
-            let name =
-                TypeName::from_type_def_or_ref(reader, required.interface(reader), &name.generics, calling_namespace);
+            let name = TypeName::from_type_def_or_ref(
+                reader,
+                required.interface(reader),
+                &name.generics,
+                calling_namespace,
+            );
             let kind = kind(reader, required);
             self.insert_type_name(reader, name, kind, calling_namespace);
         }

--- a/crates/gen/src/types/required_interfaces.rs
+++ b/crates/gen/src/types/required_interfaces.rs
@@ -7,21 +7,21 @@ use std::collections::*;
 pub struct RequiredInterfaces(pub BTreeMap<TypeName, InterfaceKind>);
 
 impl RequiredInterfaces {
-    fn insert_type_name(&mut self, reader: &TypeReader, name: TypeName, kind: InterfaceKind) {
+    fn insert_type_name(&mut self, reader: &TypeReader, name: TypeName, kind: InterfaceKind, calling_namespace:&str) {
         if !self.0.contains_key(&name) {
-            self.insert_required(reader, &name);
+            self.insert_required(reader, &name, calling_namespace);
             self.0.insert(name, kind);
         } else if kind == InterfaceKind::Default {
             self.0.insert(name, kind);
         }
     }
 
-    pub fn insert_required(&mut self, reader: &TypeReader, name: &TypeName) {
+    pub fn insert_required(&mut self, reader: &TypeReader, name: &TypeName, calling_namespace:&str) {
         for required in name.def.interfaces(reader) {
             let name =
-                TypeName::from_type_def_or_ref(reader, required.interface(reader), &name.generics);
+                TypeName::from_type_def_or_ref(reader, required.interface(reader), &name.generics, calling_namespace);
             let kind = kind(reader, required);
-            self.insert_type_name(reader, name, kind);
+            self.insert_type_name(reader, name, kind, calling_namespace);
         }
     }
 }

--- a/crates/gen/src/types/struct.rs
+++ b/crates/gen/src/types/struct.rs
@@ -38,7 +38,7 @@ impl Struct {
     }
 
     pub fn to_tokens(&self) -> TokenStream {
-        let name = &*self.name.to_tokens(&self.name.namespace);
+        let name = self.name.to_tokens(&self.name.namespace);
         let signature = &self.signature;
 
         let fields = self.fields.iter().map(|field| {

--- a/crates/gen/src/types/struct.rs
+++ b/crates/gen/src/types/struct.rs
@@ -13,12 +13,11 @@ pub struct Struct {
 }
 
 impl Struct {
-    pub fn from_type_def(reader: &TypeReader, def: TypeDef) -> Self {
-        let name = TypeName::from_type_def(reader, def);
+    pub fn from_type_name(reader: &TypeReader, name: TypeName) -> Self {
         let signature = name.struct_signature(reader);
         let mut fields = Vec::new();
 
-        for field in def.fields(reader) {
+        for field in name.def.fields(reader) {
             let name = to_snake(field.name(reader), MethodKind::Normal);
             let kind = TypeKind::from_field(reader, field);
             fields.push((name, kind));

--- a/crates/gen/src/types/struct.rs
+++ b/crates/gen/src/types/struct.rs
@@ -38,7 +38,7 @@ impl Struct {
     }
 
     pub fn to_tokens(&self) -> TokenStream {
-        let name = self.name.to_tokens(&self.name.namespace);
+        let name = &self.name.tokens;
         let signature = &self.signature;
 
         let fields = self.fields.iter().map(|field| {

--- a/crates/gen/src/types/struct.rs
+++ b/crates/gen/src/types/struct.rs
@@ -18,9 +18,9 @@ impl Struct {
         let mut fields = Vec::new();
 
         for field in name.def.fields(reader) {
-            let name = to_snake(field.name(reader), MethodKind::Normal);
-            let kind = TypeKind::from_field(reader, field);
-            fields.push((name, kind));
+            let field_name = to_snake(field.name(reader), MethodKind::Normal);
+            let kind = TypeKind::from_field(reader, field, &name.namespace);
+            fields.push((field_name, kind));
         }
 
         Self {

--- a/crates/gen/src/types/struct.rs
+++ b/crates/gen/src/types/struct.rs
@@ -43,7 +43,7 @@ impl Struct {
 
         let fields = self.fields.iter().map(|field| {
             let name = format_ident(&field.0);
-            let kind = field.1.to_tokens(&self.name.namespace);
+            let kind = field.1.to_tokens();
             quote! {
                 pub #name: #kind
             }

--- a/crates/gen/src/types/type.rs
+++ b/crates/gen/src/types/type.rs
@@ -15,14 +15,14 @@ pub enum Type {
 }
 
 impl Type {
-    // TODO: add generics param to test generic specializations?
     pub fn from_type_def(reader: &TypeReader, def: TypeDef) -> Self {
+        let name = TypeName::from_type_def(reader, def);
         match def.category(reader) {
-            TypeCategory::Interface => Self::Interface(Interface::from_type_def(reader, def)),
-            TypeCategory::Class => Self::Class(Class::from_type_def(reader, def)),
-            TypeCategory::Enum => Self::Enum(Enum::from_type_def(reader, def)),
-            TypeCategory::Struct => Self::Struct(Struct::from_type_def(reader, def)),
-            TypeCategory::Delegate => Self::Delegate(Delegate::from_type_def(reader, def)),
+            TypeCategory::Interface => Self::Interface(Interface::from_type_name(reader, name)),
+            TypeCategory::Class => Self::Class(Class::from_type_name(reader, name)),
+            TypeCategory::Enum => Self::Enum(Enum::from_type_name(reader, name)),
+            TypeCategory::Struct => Self::Struct(Struct::from_type_name(reader, name)),
+            TypeCategory::Delegate => Self::Delegate(Delegate::from_type_name(reader, name)),
         }
     }
 

--- a/crates/gen/src/types/type.rs
+++ b/crates/gen/src/types/type.rs
@@ -16,7 +16,7 @@ pub enum Type {
 
 impl Type {
     pub fn from_type_def(reader: &TypeReader, def: TypeDef) -> Self {
-        let name = TypeName::from_type_def(reader, def);
+        let name = TypeName::from_type_def(reader, def, "");
         match def.category(reader) {
             TypeCategory::Interface => Self::Interface(Interface::from_type_name(reader, name)),
             TypeCategory::Class => Self::Class(Class::from_type_name(reader, name)),

--- a/crates/gen/src/types/type_kind.rs
+++ b/crates/gen/src/types/type_kind.rs
@@ -96,37 +96,71 @@ impl TypeKind {
         }
     }
 
-    pub fn from_type_def(reader: &TypeReader, def: TypeDef, _generics: &Vec<TypeKind>, calling_namespace:&str) -> Self {
-        Self::from_type_name(reader, TypeName::from_type_def(reader, def, calling_namespace))
+    pub fn from_type_def(
+        reader: &TypeReader,
+        def: TypeDef,
+        _generics: &Vec<TypeKind>,
+        calling_namespace: &str,
+    ) -> Self {
+        Self::from_type_name(
+            reader,
+            TypeName::from_type_def(reader, def, calling_namespace),
+        )
     }
 
-    pub fn from_type_ref(reader: &TypeReader, type_ref: TypeRef, generics: &Vec<TypeKind>, calling_namespace:&str) -> Self {
+    pub fn from_type_ref(
+        reader: &TypeReader,
+        type_ref: TypeRef,
+        generics: &Vec<TypeKind>,
+        calling_namespace: &str,
+    ) -> Self {
         let (namespace, name) = type_ref.name(reader);
         if (namespace, name) == ("System", "Guid") {
             TypeKind::Guid
         } else {
-            Self::from_type_def(reader, reader.resolve_type_def((namespace, name)), generics, calling_namespace)
+            Self::from_type_def(
+                reader,
+                reader.resolve_type_def((namespace, name)),
+                generics,
+                calling_namespace,
+            )
         }
     }
 
-    pub fn from_type_spec(reader: &TypeReader, spec: TypeSpec, generics: &Vec<TypeKind>, calling_namespace: &str) -> Self {
-        TypeKind::Interface(TypeName::from_type_spec(reader, spec, generics, calling_namespace))
+    pub fn from_type_spec(
+        reader: &TypeReader,
+        spec: TypeSpec,
+        generics: &Vec<TypeKind>,
+        calling_namespace: &str,
+    ) -> Self {
+        TypeKind::Interface(TypeName::from_type_spec(
+            reader,
+            spec,
+            generics,
+            calling_namespace,
+        ))
     }
 
     fn from_type_def_or_ref(
         reader: &TypeReader,
         code: TypeDefOrRef,
         generics: &Vec<TypeKind>,
-        calling_namespace:&str
+        calling_namespace: &str,
     ) -> Self {
         match code {
-            TypeDefOrRef::TypeRef(value) => Self::from_type_ref(reader, value, generics, calling_namespace),
-            TypeDefOrRef::TypeDef(value) => Self::from_type_def(reader, value, generics,calling_namespace),
-            TypeDefOrRef::TypeSpec(value) => Self::from_type_spec(reader, value, generics,calling_namespace),
+            TypeDefOrRef::TypeRef(value) => {
+                Self::from_type_ref(reader, value, generics, calling_namespace)
+            }
+            TypeDefOrRef::TypeDef(value) => {
+                Self::from_type_def(reader, value, generics, calling_namespace)
+            }
+            TypeDefOrRef::TypeSpec(value) => {
+                Self::from_type_spec(reader, value, generics, calling_namespace)
+            }
         }
     }
 
-    pub fn from_blob(blob: &mut Blob, generics: &Vec<TypeKind>, calling_namespace:&str) -> Self {
+    pub fn from_blob(blob: &mut Blob, generics: &Vec<TypeKind>, calling_namespace: &str) -> Self {
         blob.read_expected(0x1D);
         blob.read_modifiers();
 
@@ -149,17 +183,18 @@ impl TypeKind {
                 blob.reader,
                 TypeDefOrRef::decode(blob.read_unsigned(), blob.file_index),
                 generics,
-                calling_namespace
+                calling_namespace,
             ),
             0x13 => generics[blob.read_unsigned() as usize].clone(),
-            0x15 => {
-                Self::from_type_name(blob.reader, TypeName::from_type_spec_blob(blob, generics, calling_namespace))
-            }
+            0x15 => Self::from_type_name(
+                blob.reader,
+                TypeName::from_type_spec_blob(blob, generics, calling_namespace),
+            ),
             _ => panic!("TypeKind::from_blob"),
         }
     }
 
-    pub fn from_field(reader: &TypeReader, field: Field, calling_namespace:&str) -> Self {
+    pub fn from_field(reader: &TypeReader, field: Field, calling_namespace: &str) -> Self {
         let mut blob = field.sig(reader);
         blob.read_unsigned();
         blob.read_modifiers();

--- a/crates/gen/src/types/type_kind.rs
+++ b/crates/gen/src/types/type_kind.rs
@@ -177,7 +177,7 @@ impl TypeKind {
         }
     }
 
-    pub fn to_tokens(&self, calling_namespace: &str) -> TokenStream {
+    pub fn to_tokens(&self) -> TokenStream {
         match self {
             Self::Bool => quote! { bool },
             Self::Char => quote! { u16 },
@@ -206,7 +206,7 @@ impl TypeKind {
         }
     }
 
-    pub fn to_abi_tokens(&self, calling_namespace: &str) -> TokenStream {
+    pub fn to_abi_tokens(&self) -> TokenStream {
         match self {
             Self::Bool => quote! { bool, },
             Self::Char => quote! { u16, },

--- a/crates/gen/src/types/type_kind.rs
+++ b/crates/gen/src/types/type_kind.rs
@@ -234,7 +234,7 @@ impl TypeKind {
             | Self::Delegate(name)
             | Self::Enum(name)
             | Self::Struct(name) => {
-                let name = &*name.to_tokens(calling_namespace);
+                let name = name.to_tokens(calling_namespace);
                 quote! { <#name as ::winrt::AbiTransferable>::Abi, }
             }
         }

--- a/crates/gen/src/types/type_kind.rs
+++ b/crates/gen/src/types/type_kind.rs
@@ -194,11 +194,11 @@ impl TypeKind {
             Self::String => quote! { ::winrt::HString },
             Self::Object => quote! { ::winrt::Object },
             Self::Guid => quote! { ::winrt::Guid },
-            Self::Class(name) => name.to_tokens(calling_namespace).clone(),
-            Self::Interface(name) => name.to_tokens(calling_namespace).clone(),
-            Self::Enum(name) => name.to_tokens(calling_namespace).clone(),
-            Self::Struct(name) => name.to_tokens(calling_namespace).clone(),
-            Self::Delegate(name) => name.to_tokens(calling_namespace).clone(),
+            Self::Class(name) => name.tokens.clone(),
+            Self::Interface(name) => name.tokens.clone(),
+            Self::Enum(name) => name.tokens.clone(),
+            Self::Struct(name) => name.tokens.clone(),
+            Self::Delegate(name) => name.tokens.clone(),
             Self::Generic(name) => {
                 let name = format_ident(name);
                 quote! { #name }
@@ -236,7 +236,7 @@ impl TypeKind {
             | Self::Delegate(name)
             | Self::Enum(name)
             | Self::Struct(name) => {
-                let name = name.to_tokens(calling_namespace);
+                let name = &name.tokens;
                 quote! { <#name as ::winrt::AbiTransferable>::Abi, }
             }
         }

--- a/crates/gen/src/types/type_name.rs
+++ b/crates/gen/src/types/type_name.rs
@@ -307,9 +307,9 @@ impl TypeName {
     /// Crate abi tokens
     ///
     /// For example: `abi_Vector<OtherType>`
-    pub fn to_abi_tokens(&self, calling_namespace: &str) -> TokenStream {
-        let namespace = to_namespace_tokens(&self.namespace, calling_namespace);
-        self.generate_tokens(Some(&namespace), calling_namespace, format_abi_ident)
+    pub fn to_abi_tokens(&self) -> TokenStream {
+        let namespace = to_namespace_tokens(&self.namespace, &self.calling_namespace);
+        self.generate_tokens(Some(&namespace),  format_abi_ident)
     }
 
     /// Crate definition tokens
@@ -319,15 +319,15 @@ impl TypeName {
     /// Note: ideally to_definition_tokens and to_abi_definiton_tokens would not be required
     /// and we would simply use to_tokens and to_abi_tokens everywhere but Rust is really
     /// weird in requiring `IVector<T>` in some places and `IVector::<T>` in others.
-    pub fn to_definition_tokens(&self, calling_namespace: &str) -> TokenStream {
-        self.generate_tokens(None, calling_namespace, format_ident)
+    pub fn to_definition_tokens(&self) -> TokenStream {
+        self.generate_tokens(None,  format_ident)
     }
 
     /// Crate abi definition tokens
     ///
     /// For example: `abi_Vector::<OtherType>`
-    pub fn to_abi_definition_tokens(&self, calling_namespace: &str) -> TokenStream {
-        self.generate_tokens(None, calling_namespace, format_abi_ident)
+    pub fn to_abi_definition_tokens(&self) -> TokenStream {
+        self.generate_tokens(None,  format_abi_ident)
     }
 
     /// Generate the definition tokens for a type
@@ -339,7 +339,6 @@ impl TypeName {
     fn generate_tokens<F>(
         &self,
         namespace: Option<&TokenStream>,
-        calling_namespace: &str,
         format: F,
     ) -> TokenStream
     where
@@ -351,7 +350,7 @@ impl TypeName {
         } else {
             let colon_separated = namespace.map(|_| quote! { :: });
             let name = format(&self.name[..self.name.len() - 2]);
-            let generics = self.generics.iter().map(|g| g.to_tokens(calling_namespace));
+            let generics = self.generics.iter().map(|g| g.to_tokens(&self.calling_namespace));
             quote! { #namespace#name#colon_separated<#(#generics),*> }
         }
     }

--- a/crates/gen/src/types/type_name.rs
+++ b/crates/gen/src/types/type_name.rs
@@ -28,8 +28,8 @@ pub struct TypeName {
     pub constraints: TokenStream,
     // The namespace of the type being tokenized.
     calling_namespace: String,
-    // Cached TokenStream for the calling namespace
-    tokens: TokenStream,
+    /// Cached TokenStream for the calling namespace
+    pub tokens: TokenStream,
 }
 
 impl TypeName {
@@ -302,15 +302,6 @@ impl TypeName {
         std::iter::once(self.def)
             .chain(self.generics.iter().flat_map(|i| i.dependencies()))
             .collect()
-    }
-
-    /// Crate tokens
-    ///
-    /// For example: `Vector<OtherType>`
-    pub fn to_tokens(&self, calling_namespace: &str) -> TokenStream {
-        // let namespace = to_namespace_tokens(&self.namespace, &self.calling_namespace);
-        // self.generate_tokens(Some(&namespace), &self.calling_namespace, format_ident)
-        self.tokens.clone()
     }
 
     /// Crate abi tokens

--- a/crates/gen/src/types/type_name.rs
+++ b/crates/gen/src/types/type_name.rs
@@ -30,6 +30,11 @@ pub struct TypeName {
     constraints: TokenStream,
     // Cached TokenStream keyed off of the calling namespace
     tokens: RefCell<HashMap<String, TokenStream>>,
+
+    // TODO: remove `tokens` above.
+    tokens2: TokenStream,
+
+    calling_namespace: String,
 }
 
 impl TypeName {
@@ -46,6 +51,8 @@ impl TypeName {
             def,
             constraints,
             tokens: RefCell::new(HashMap::new()),
+            tokens2: TokenStream::new(),
+            calling_namespace: String::new(),
         }
     }
 
@@ -76,6 +83,8 @@ impl TypeName {
             let name = generic.name(reader).to_string();
             generics.push(TypeKind::Generic(name));
         }
+
+        //let calling_namespace = if calling_namespace.is_empty() { &namespace } else { calling_namespace };
 
         Self::new(namespace, name, generics, def)
     }
@@ -423,185 +432,4 @@ impl Ord for TypeName {
 
 fn format_abi_ident(name: &str) -> proc_macro2::Ident {
     quote::format_ident!("abi_{}", name)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::file::TableIndex;
-    use crate::row::Row;
-
-    #[test]
-    fn runtime_name() {
-        let mut type_name = TypeName::new(
-            String::from("Outer.Inner"),
-            String::from("MyType"),
-            vec![],
-            TypeDef(Row {
-                index: 0,
-                table_index: TableIndex::InterfaceImpl,
-                file_index: 0,
-            }),
-        );
-
-        assert_eq!(type_name.runtime_name(), String::from("Outer.Inner.MyType"));
-
-        type_name.generics = vec![TypeKind::Bool];
-
-        assert_eq!(
-            type_name.runtime_name(),
-            String::from("Outer.Inner.MyType<Boolean>")
-        );
-
-        type_name.generics = vec![TypeKind::Bool, TypeKind::U8];
-
-        assert_eq!(
-            type_name.runtime_name(),
-            String::from("Outer.Inner.MyType<Boolean, UInt8>")
-        );
-    }
-
-    #[test]
-    fn guids() {
-        let reader = &TypeReader::from_os();
-
-        // Non-generic interface guid
-        let def = reader.resolve_type_def(("Windows.Foundation", "IAsyncAction"));
-        let name = def.into_type(reader).name().clone();
-        assert!(
-            format!("{{{:#?}}}", name.guid(reader, false))
-                == "{5a648006-843a-4da9-865b-9d26e5dfad7b}"
-        );
-
-        // Generic interface guid
-        let stringable = reader.resolve_type_def(("Windows.Foundation", "IStringable"));
-        let stringable = stringable.into_type(reader).name().clone();
-        let def = reader.resolve_type_def(("Windows.Foundation.Collections", "IVector`1"));
-        let mut name = def.into_type(reader).name().clone();
-        name.generics.clear();
-        name.generics.push(TypeKind::Interface(stringable));
-        assert!(
-            format!("{{{:#?}}}", name.guid(reader, false))
-                == "{14b954c2-2914-530e-84a7-9473e2fb24e2}"
-        );
-
-        // Generic interface guid
-        let stringable = reader.resolve_type_def(("Windows.Foundation", "IWwwFormUrlDecoderEntry"));
-        let stringable = stringable.into_type(reader).name().clone();
-        let def = reader.resolve_type_def(("Windows.Foundation.Collections", "IVectorView`1"));
-        let mut name = def.into_type(reader).name().clone();
-        name.generics.clear();
-        name.generics.push(TypeKind::Interface(stringable));
-        let guid = name.guid(reader, false);
-        assert!(format!("{{{:#?}}}", guid) == "{b1f00d3b-1f06-5117-93ea-2a0d79116701}");
-
-        // Unspecialized generic guid
-        let def = reader.resolve_type_def(("Windows.Foundation.Collections", "IVector`1"));
-        let name = def.into_type(reader).name().clone();
-        assert!(
-            format!("{{{:#?}}}", name.guid(reader, true))
-                == "{913337e9-11a1-4345-a3a2-4e7f956e222d}"
-        );
-    }
-
-    #[test]
-    fn signatures() {
-        let reader = &TypeReader::from_os();
-
-        // Primitive signatures
-        assert!(TypeKind::Bool.signature(reader) == "b1");
-        assert!(TypeKind::Char.signature(reader) == "c2");
-        assert!(TypeKind::I8.signature(reader) == "i1");
-        assert!(TypeKind::U8.signature(reader) == "u1");
-        assert!(TypeKind::I16.signature(reader) == "i2");
-        assert!(TypeKind::U16.signature(reader) == "u2");
-        assert!(TypeKind::I32.signature(reader) == "i4");
-        assert!(TypeKind::U32.signature(reader) == "u4");
-        assert!(TypeKind::I64.signature(reader) == "i8");
-        assert!(TypeKind::U64.signature(reader) == "u8");
-        assert!(TypeKind::F32.signature(reader) == "f4");
-        assert!(TypeKind::F64.signature(reader) == "f8");
-        assert!(TypeKind::String.signature(reader) == "string");
-        assert!(TypeKind::Object.signature(reader) == "cinterface(IInspectable)");
-        assert!(TypeKind::Guid.signature(reader) == "g16");
-
-        // Non-generic interface signature
-        let def = reader.resolve_type_def(("Windows.Foundation", "IAsyncAction"));
-        let name = def.into_type(reader).name().clone();
-        assert!(
-            TypeKind::Interface(name).signature(reader) == "{5a648006-843a-4da9-865b-9d26e5dfad7b}"
-        );
-
-        // Generic interface signature
-        let def = reader.resolve_type_def(("Windows.Foundation.Collections", "IVector`1"));
-        let mut name = def.into_type(reader).name().clone();
-        name.generics.clear();
-        name.generics.push(TypeKind::I32);
-        assert!(
-            TypeKind::Interface(name).signature(reader)
-                == "pinterface({913337e9-11a1-4345-a3a2-4e7f956e222d};i4)"
-        );
-
-        // Signed enum signature
-        let def = reader.resolve_type_def(("Windows.Foundation", "AsyncStatus"));
-        let name = def.into_type(reader).name().clone();
-        assert!(
-            TypeKind::Enum(name).signature(reader) == "enum(Windows.Foundation.AsyncStatus;i4)"
-        );
-
-        // Unsigned enum signature
-        let def = reader.resolve_type_def((
-            "Windows.ApplicationModel.Appointments",
-            "AppointmentDaysOfWeek",
-        ));
-        let name = def.into_type(reader).name().clone();
-        assert!(
-            TypeKind::Enum(name).signature(reader)
-                == "enum(Windows.ApplicationModel.Appointments.AppointmentDaysOfWeek;u4)"
-        );
-
-        // Non-generic delegate signature
-        let def = reader.resolve_type_def(("Windows.Foundation", "AsyncActionCompletedHandler"));
-        let name = def.into_type(reader).name().clone();
-        assert!(
-            TypeKind::Delegate(name).signature(reader)
-                == "delegate({a4ed5c81-76c9-40bd-8be6-b1d90fb20ae7})"
-        );
-
-        // Generic delegate signature
-        let stringable = reader.resolve_type_def(("Windows.Foundation", "IStringable"));
-        let stringable = stringable.into_type(reader).name().clone();
-
-        let def = reader.resolve_type_def(("Windows.Foundation", "EventHandler`1"));
-        let mut name = def.into_type(reader).name().clone();
-        name.generics.clear();
-        name.generics.push(TypeKind::Interface(stringable));
-        assert!(
-            TypeKind::Delegate(name).signature(reader) == "pinterface({9de1c535-6ae1-11e0-84e1-18a905bcc53f};{96369f54-8eb6-48f0-abce-c1b211e627c3})"
-        );
-
-        // Class signature
-        let def = reader.resolve_type_def(("Windows.Foundation", "Uri"));
-        let name = def.into_type(reader).name().clone();
-        assert!(
-            TypeKind::Class(name).signature(reader)
-                == "rc(Windows.Foundation.Uri;{9e365e57-48b2-4160-956f-c7385120bbfc})"
-        );
-
-        // Class with generic default interface signature
-        let def = reader.resolve_type_def(("Windows.Foundation", "WwwFormUrlDecoder"));
-        let name = def.into_type(reader).name().clone();
-        assert!(
-            TypeKind::Class(name).signature(reader)
-                == "rc(Windows.Foundation.WwwFormUrlDecoder;{d45a0451-f225-4542-9296-0e1df5d254df})"
-        );
-
-        // Simple struct
-        let def = reader.resolve_type_def(("Windows.Foundation", "Rect"));
-        let name = def.into_type(reader).name().clone();
-        assert!(
-            TypeKind::Struct(name).signature(reader)
-                == "struct(Windows.Foundation.Rect;f4;f4;f4;f4)"
-        );
-    }
 }

--- a/crates/gen/src/types/type_name.rs
+++ b/crates/gen/src/types/type_name.rs
@@ -450,7 +450,6 @@ where
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -206,9 +206,10 @@ impl ImportMacro {
         println!("TypeTree {}s", now.elapsed().unwrap().as_secs());
         let now = std::time::SystemTime::now();
 
-        let tokens = tree.to_tokens()
-        .collect::<proc_macro2::TokenStream>()
-        .into();
+        let tokens = tree
+            .to_tokens()
+            .collect::<proc_macro2::TokenStream>()
+            .into();
         println!("TokenStream {}s", now.elapsed().unwrap().as_secs());
 
         tokens

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -59,8 +59,9 @@ use std::{collections::BTreeSet, path::PathBuf};
 #[proc_macro]
 pub fn import(stream: TokenStream) -> TokenStream {
     let import = parse_macro_input!(stream as ImportMacro);
-    let _tokens = import.to_tokens();
-    TokenStream::new()
+    let tokens = import.to_tokens();
+    //TokenStream::new()
+    tokens
 }
 
 /// A macro for generating WinRT modules to a .rs file at build time.

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -172,21 +172,15 @@ impl ImportMacro {
     }
 
     fn to_tokens(self) -> TokenStream {
-        let now = std::time::SystemTime::now();
-
         let dependencies = self
             .dependencies
             .0
             .iter()
             .map(|p| WinmdFile::new(p))
             .collect();
-        let reader = &TypeReader::new(dependencies);
-        println!("TypeReader {}s", now.elapsed().unwrap().as_secs());
-        let now = std::time::SystemTime::now();
 
+        let reader = &TypeReader::new(dependencies);
         let mut limits = TypeLimits::new(reader);
-        println!("TypeLimits {}s", now.elapsed().unwrap().as_secs());
-        let now = std::time::SystemTime::now();
 
         for limit in self.types.0 {
             let types = limit.types;
@@ -199,20 +193,11 @@ impl ImportMacro {
         }
 
         let stage = TypeStage::from_limits(reader, &limits);
-        println!("TypeStage {}s", now.elapsed().unwrap().as_secs());
-        let now = std::time::SystemTime::now();
-
         let tree = stage.into_tree();
-        println!("TypeTree {}s", now.elapsed().unwrap().as_secs());
-        let now = std::time::SystemTime::now();
 
-        let tokens = tree
-            .to_tokens()
+        tree.to_tokens()
             .collect::<proc_macro2::TokenStream>()
-            .into();
-        println!("TokenStream {}s", now.elapsed().unwrap().as_secs());
-
-        tokens
+            .into()
     }
 }
 

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -59,9 +59,7 @@ use std::{collections::BTreeSet, path::PathBuf};
 #[proc_macro]
 pub fn import(stream: TokenStream) -> TokenStream {
     let import = parse_macro_input!(stream as ImportMacro);
-    let tokens = import.to_tokens();
-    //TokenStream::new()
-    tokens
+    import.to_tokens()
 }
 
 /// A macro for generating WinRT modules to a .rs file at build time.

--- a/tests/xaml.rs
+++ b/tests/xaml.rs
@@ -6,5 +6,9 @@ winrt::import!(
 );
 #[test]
 fn xaml() -> winrt::Result<()> {
+    use winrt::ComInterface;
+    let app = windows::ui::xaml::Application::default();
+    assert!(app.is_null());
+
     Ok(())
 }

--- a/tests/xaml.rs
+++ b/tests/xaml.rs
@@ -1,0 +1,10 @@
+winrt::import!(
+    dependencies
+        os
+    types
+        windows::ui::xaml::*
+);
+#[test]
+fn xaml() -> winrt::Result<()> {
+    Ok(())
+}


### PR DESCRIPTION
This is quite a big change to pay down some technical debt around how calling namespaces are calculated during tokenization. Rather than repeatedly generating tokens for type names, we calculate the calling namespace at the point at which the type name is created and then cache as appropriate. 

There is probably more opportunity to cache and clean up the code, but this overhaul is pretty substantial and I'd rather leave it here and address the remaining improvements separately.

Even though this work wasn't done to improve performance specifically, this does improve tokenization performance by about 20%. 

I also reintroduced a basic test for xaml as it ended up uncovering a few tokenization bugs that weren't covered by other tests. Once formal testing is introduced (https://github.com/microsoft/winrt-rs/issues/213), we'll be able to remove this again as it is quite slow (the Rust compiler is quite slow at parsing all of generated code).


