### PR TITLE
Dynamically load Windows 10 APIs.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ readme = "README.md"
 [dependencies]
 winrt_macros = { path = "crates/macros",  version = "0.7" }
 sha1 = "0.6.0"
+wchar = "0.6.0"
 
 [dev-dependencies]
 doc-comment = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ readme = "README.md"
 [dependencies]
 winrt_macros = { path = "crates/macros",  version = "0.7" }
 sha1 = "0.6.0"
-wchar = "0.6.0"
 
 [dev-dependencies]
 doc-comment = "0.3"

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,8 +22,10 @@ impl Error {
         let message: HString = message.into();
 
         // RoOriginateError creates the error object and associates it with the thread.
+        // Need to ignore the result, as that is the delay-load error, which would mean
+        // that there's no WinRT to tell about the error.
         unsafe {
-            RoOriginateError(code, message.get_abi() as _);
+            let _ = RoOriginateError(code, message.get_abi() as _);
         }
 
         let mut info = IErrorInfo::default();
@@ -137,8 +139,10 @@ impl<T> std::convert::From<Result<T>> for ErrorCode {
             if let Some(info) = error.info.get_abi() {
                 // Set the error information on the thread if the result is `Err`
                 // so that the caller can pick it up.
+                // Need to ignore the result, as that is the delay-load error, which would mean
+                // that there's no WinRT to tell about the error.
                 unsafe {
-                    SetRestrictedErrorInfo(info.as_raw() as _);
+                    let _ = SetRestrictedErrorInfo(info.as_raw() as _);
                 }
             }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -131,6 +131,19 @@ impl ErrorCode {
 
     /// Indicates that COM has not been initialized.
     pub(crate) const NOT_INITIALIZED: ErrorCode = ErrorCode(0x8004_01F0);
+
+    /// Creates a failure code from GetLastError()
+    #[inline]
+    pub(crate) fn last_win32_error() -> Self {
+        Self::from_win32(unsafe { GetLastError() })
+    }
+
+    /// Creates a failure code with the provided win32 error code.
+    #[inline]
+    pub(crate) fn from_win32(error: u32) -> Self {
+        // equivalent to MAKE_WIN32_HRESULT(error)
+        Self(0x8007_0000 | error & 0xFFFF)
+    }
 }
 
 impl<T> std::convert::From<Result<T>> for ErrorCode {

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -9,19 +9,27 @@ pub fn factory<C: RuntimeName, I: ComInterface>() -> Result<I> {
 
     unsafe {
         // First attempt to get the activation factory via the OS.
-        let mut code = RoGetActivationFactory(name.get_abi(), &I::iid(), &mut factory)?;
+        let code = RoGetActivationFactory(name.get_abi(), &I::iid(), &mut factory);
+
+        // Treat any delay-load errors like standard errors, so that the heuristics
+        // below can still load registration-free libraries on Windows versions below 10.
+        let mut code = code.unwrap_or_else(|code| code);
 
         // If this fails because combase hasn't been loaded yet then load combase
         // automatically so that it "just works" for apartment-agnostic code.
         if code == ErrorCode::NOT_INITIALIZED {
             let mut _cookie = std::ptr::null_mut();
-            CoIncrementMTAUsage(&mut _cookie)?;
+
+            // Won't get any delay-load errors here if we got NOT_INITIALIZED, so quiet the
+            // warning from the #[must_use] on the returned Result<>.
+            let _ = CoIncrementMTAUsage(&mut _cookie);
 
             // Now try a second time to get the activation factory via the OS.
-            code = RoGetActivationFactory(name.get_abi(), &I::iid(), &mut factory)?;
+            code = RoGetActivationFactory(name.get_abi(), &I::iid(), &mut factory)
+                .unwrap_or_else(|code| code);
         }
 
-        // If this succeeded then retun the resulting factory interface.
+        // If this succeeded then return the resulting factory interface.
         if code.is_ok() {
             return Ok(std::mem::transmute_copy(&factory));
         }
@@ -47,7 +55,8 @@ pub fn factory<C: RuntimeName, I: ComInterface>() -> Result<I> {
                 .collect();
 
             // Attempt to load the DLL.
-            let library = Library::from_handle(LoadLibraryW(path.as_ptr()));
+            let library =
+                Library::from_handle(LoadLibraryExW(path.as_ptr(), std::ptr::null_mut(), 0));
 
             if library.handle.is_null() {
                 continue;

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -9,16 +9,16 @@ pub fn factory<C: RuntimeName, I: ComInterface>() -> Result<I> {
 
     unsafe {
         // First attempt to get the activation factory via the OS.
-        let mut code = RoGetActivationFactory(name.get_abi(), &I::iid(), &mut factory);
+        let mut code = RoGetActivationFactory(name.get_abi(), &I::iid(), &mut factory)?;
 
         // If this fails because combase hasn't been loaded yet then load combase
         // automatically so that it "just works" for apartment-agnostic code.
         if code == ErrorCode::NOT_INITIALIZED {
             let mut _cookie = std::ptr::null_mut();
-            CoIncrementMTAUsage(&mut _cookie);
+            CoIncrementMTAUsage(&mut _cookie)?;
 
             // Now try a second time to get the activation factory via the OS.
-            code = RoGetActivationFactory(name.get_abi(), &I::iid(), &mut factory);
+            code = RoGetActivationFactory(name.get_abi(), &I::iid(), &mut factory)?;
         }
 
         // If this succeeded then retun the resulting factory interface.

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -30,21 +30,23 @@ extern "system" {
     ) -> u32;
 }
 
-unsafe fn load_proc(library_name: &str, sym: &str) -> Result<RawPtr, ErrorCode> {
+fn load_proc(library_name: &str, sym: &str) -> Result<RawPtr, ErrorCode> {
     let library_name = library_name
         .encode_utf16()
         .chain(std::iter::once(0))
         .collect::<Vec<u16>>();
 
-    let library = LoadLibraryExW(
-        library_name.as_ptr(),
-        std::ptr::null_mut(),
-        LOAD_LIBRARY_SEARCH_SYSTEM32,
-    );
+    let library = unsafe {
+        LoadLibraryExW(
+            library_name.as_ptr(),
+            std::ptr::null_mut(),
+            LOAD_LIBRARY_SEARCH_SYSTEM32,
+        )
+    };
     if library.is_null() {
         return Err(ErrorCode::last_win32_error());
     }
-    let addr = GetProcAddress(library, sym.as_ptr());
+    let addr = unsafe { GetProcAddress(library, sym.as_ptr()) };
     if addr.is_null() {
         return Err(ErrorCode::last_win32_error());
     }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -42,7 +42,7 @@ unsafe fn load_proc(library: &[u16], sym: &str) -> Result<RawPtr, ErrorCode> {
 
 macro_rules! demand_load {
     ( $( $library:literal {
-        $(pub extern $($abi: literal)? fn $sym:ident ( $( $param: ident : $pty: ty ),* $(,)? ) -> $rt: ty;)*
+        $(pub fn $sym:ident ( $( $param: ident : $pty: ty ),* $(,)? ) -> $rt: ty;)*
     } )* ) => {
         $($(
             #[allow(non_snake_case)]
@@ -60,7 +60,7 @@ macro_rules! demand_load {
 
                 // Transmute doesn't work on generic types, as you can't constrain to a
                 // function pointer.
-                type FnPtr = extern $($abi)? fn ( $( $param: $pty ),* ) -> $rt;
+                type FnPtr = extern "system" fn ( $( $param: $pty ),* ) -> $rt;
                 let f = std::mem::transmute::<RawPtr, FnPtr>(VALUE.assume_init()?);
                 Ok( (f)( $( $param ),* ) )
             }
@@ -70,12 +70,12 @@ macro_rules! demand_load {
 
 demand_load! {
     "ole32.dll" {
-        pub extern "system" fn CoIncrementMTAUsage(cookie: *mut RawPtr) -> ErrorCode;
+        pub fn CoIncrementMTAUsage(cookie: *mut RawPtr) -> ErrorCode;
     }
     "combase.dll" {
-        pub extern "system" fn RoGetActivationFactory(hstring: *mut hstring::Header, interface: &Guid, result: *mut RawPtr) -> ErrorCode;
-        pub extern "system" fn SetRestrictedErrorInfo(info: RawPtr) -> ErrorCode;
-        pub extern "system" fn RoOriginateError(code: ErrorCode, message: RawPtr) -> i32;
+        pub fn RoGetActivationFactory(hstring: *mut hstring::Header, interface: &Guid, result: *mut RawPtr) -> ErrorCode;
+        pub fn SetRestrictedErrorInfo(info: RawPtr) -> ErrorCode;
+        pub fn RoOriginateError(code: ErrorCode, message: RawPtr) -> i32;
     }
 }
 


### PR DESCRIPTION
This allows dependent crates to be able to run down-level.

The user experience is APIs return an `Error` where `code()` returns
`ErrorCode(HRESULT_FROM_WIN32(ERROR_MOD_NOT_FOUND))`
("The specified module could not be found.").

Tested on Windows 7 with the `Windows.System.UserProfile.GlobalizationPreferences.Languages` API.

Should probably also include a test in the `.gitlab/workflows/build.yml`, but I don't really
understand what would be needed in there. An exhaustive test of all APIs is probably overkill?