### PR TITLE
Properly move over DLLs

### DIFF
--- a/crates/cargo-winrt/Cargo.toml
+++ b/crates/cargo-winrt/Cargo.toml
@@ -19,3 +19,4 @@ zip = "0.5"
 console = "0.11"
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
+once_cell = { version = "1.4", default_features = false }

--- a/crates/cargo-winrt/Cargo.toml
+++ b/crates/cargo-winrt/Cargo.toml
@@ -18,4 +18,4 @@ anyhow = "1.0"
 zip = "0.5"
 console = "0.11"
 serde_json = "1.0"
-serde = { version = "1.0.111", features = ["derive"] }
+serde = { version = "1.0", features = ["derive"] }

--- a/crates/cargo-winrt/src/main.rs
+++ b/crates/cargo-winrt/src/main.rs
@@ -472,7 +472,7 @@ impl Dll {
             std::fs::create_dir_all(&profile_path)?;
             let arch = self.name.parent().unwrap();
             let dll_path = profile_path.join(&self.name.strip_prefix(&arch).unwrap());
-            if arch.as_os_str() == "win-x64" && std::fs::read_link(&dll_path).is_err() {
+            if arch.as_os_str() == ARCH && std::fs::read_link(&dll_path).is_err() {
                 std::os::windows::fs::symlink_file(&path, dll_path)?;
             }
         }
@@ -480,3 +480,12 @@ impl Dll {
         Ok(())
     }
 }
+
+#[cfg(target_arch = "x86_64")]
+const ARCH: &str = "win10-x64";
+#[cfg(target_arch = "x86")]
+const ARCH: &str = "win10-x86";
+#[cfg(target_arch = "arm")]
+const ARCH: &str = "win10-arm";
+#[cfg(target_arch = "aarch64")]
+const ARCH: &str = "win10-arm64";

--- a/crates/cargo-winrt/src/manifest.rs
+++ b/crates/cargo-winrt/src/manifest.rs
@@ -13,6 +13,14 @@ impl Manifest {
         Ok(Manifest(ManifestImpl::from_slice(data)?))
     }
 
+    pub(crate) fn package_name(&self) -> &str {
+        self.0
+            .package
+            .as_ref()
+            .map(|p| p.name.as_ref())
+            .unwrap_or("")
+    }
+
     pub(crate) fn get_dependency_descriptors(self) -> anyhow::Result<Vec<DependencyDescriptor>> {
         let metadata = self.0.package.and_then(|p| p.metadata);
 

--- a/crates/cargo-winrt/src/manifest.rs
+++ b/crates/cargo-winrt/src/manifest.rs
@@ -91,7 +91,11 @@ fn dependency_descriptors_from_metadata(
                         path: path.into(),
                     }),
                     _ => bail!(Error::MalformedManifest(
-                        anyhow!("expected either a `version`, `url`, or `path` string").into(),
+                        anyhow!(
+                            "expected either a `version`, `url`, or `path` string for nuget package '{}'",
+                            key
+                        )
+                        .into(),
                     )),
                 }
             }


### PR DESCRIPTION
This PR fixes an issue reported in #233 where dlls were not being properly moved over from the `nuget` directory to the debug and release directories. The issue was that we were looking for targets in the form of `win-$ARCH` instead of `win10-$ARCH`. 

Additionally this improves logging by adding a `--verbose` flag which can help with simply debugging. 