### PR TITLE
Add Debug derives for type_code generated types

### DIFF
--- a/crates/gen/macros/src/lib.rs
+++ b/crates/gen/macros/src/lib.rs
@@ -51,7 +51,7 @@ pub fn type_code(args: TokenStream, input: TokenStream) -> TokenStream {
     let encodes = TokenStream2::from_iter(encodes);
 
     let output = quote!(
-        #[derive(Copy, Clone, PartialEq, PartialOrd, Eq, Ord)]
+        #[derive(Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Debug)]
         pub enum #name {
             #variants
         }

--- a/crates/gen/src/element_type.rs
+++ b/crates/gen/src/element_type.rs
@@ -1,6 +1,7 @@
 use crate::blob::Blob;
 use crate::codes::{Decode, TypeDefOrRef};
 
+#[derive(Debug)]
 pub enum ElementType {
     Void,
     Boolean,
@@ -44,29 +45,6 @@ impl ElementType {
             0x12 => ElementType::Class(TypeDefOrRef::decode(blob.read_unsigned(), blob.file_index)),
 
             unknown_type => panic!(format!("Unexpected ElementType: {:x}", unknown_type)),
-        }
-    }
-}
-
-impl std::fmt::Debug for ElementType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            ElementType::Void => write!(f, "ElementType::Void"),
-            ElementType::Boolean => write!(f, "ElementType::Boolean"),
-            ElementType::Char => write!(f, "ElementType::Char"),
-            ElementType::I1 => write!(f, "ElementType::I1"),
-            ElementType::U1 => write!(f, "ElementType::U1"),
-            ElementType::I2 => write!(f, "ElementType::I2"),
-            ElementType::U2 => write!(f, "ElementType::U2"),
-            ElementType::I4 => write!(f, "ElementType::I4"),
-            ElementType::U4 => write!(f, "ElementType::U4"),
-            ElementType::I8 => write!(f, "ElementType::I8"),
-            ElementType::U8 => write!(f, "ElementType::U8"),
-            ElementType::R4 => write!(f, "ElementType::R4"),
-            ElementType::R8 => write!(f, "ElementType::R8"),
-            ElementType::String => write!(f, "ElementType::String"),
-            ElementType::ValueType(_) => write!(f, "ElementType::ValueType"),
-            ElementType::Class(_) => write!(f, "ElementType::Class"),
         }
     }
 }

--- a/crates/gen/src/tables/field.rs
+++ b/crates/gen/src/tables/field.rs
@@ -6,7 +6,7 @@ use crate::row::Row;
 use crate::tables::Constant;
 use crate::TypeReader;
 
-#[derive(Copy, Clone, PartialEq, PartialOrd, Eq, Ord)]
+#[derive(Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Debug)]
 pub struct Field(pub Row);
 
 impl Field {

--- a/crates/gen/src/tables/generic_param.rs
+++ b/crates/gen/src/tables/generic_param.rs
@@ -1,7 +1,7 @@
 use crate::row::Row;
 use crate::TypeReader;
 
-#[derive(Copy, Clone, PartialEq, PartialOrd, Eq, Ord)]
+#[derive(Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Debug)]
 pub struct GenericParam(pub Row);
 
 impl GenericParam {

--- a/crates/gen/src/tables/interface_impl.rs
+++ b/crates/gen/src/tables/interface_impl.rs
@@ -4,7 +4,7 @@ use crate::file::TableIndex;
 use crate::row::Row;
 use crate::TypeReader;
 
-#[derive(Copy, Clone, PartialEq, PartialOrd, Eq, Ord)]
+#[derive(Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Debug)]
 pub struct InterfaceImpl(pub Row);
 
 impl InterfaceImpl {

--- a/crates/gen/src/tables/member_ref.rs
+++ b/crates/gen/src/tables/member_ref.rs
@@ -2,7 +2,7 @@ use crate::codes::MemberRefParent;
 use crate::row::Row;
 use crate::TypeReader;
 
-#[derive(Copy, Clone, PartialEq, PartialOrd, Eq, Ord)]
+#[derive(Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Debug)]
 pub struct MemberRef(pub Row);
 
 impl MemberRef {

--- a/crates/gen/src/tables/method_def.rs
+++ b/crates/gen/src/tables/method_def.rs
@@ -6,7 +6,7 @@ use crate::flags::{MethodCategory, MethodFlags};
 use crate::row::Row;
 use crate::TypeReader;
 
-#[derive(Copy, Clone, PartialEq, PartialOrd, Eq, Ord)]
+#[derive(Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Debug)]
 pub struct MethodDef(pub Row);
 
 impl MethodDef {

--- a/crates/gen/src/tables/param.rs
+++ b/crates/gen/src/tables/param.rs
@@ -2,7 +2,7 @@ use crate::flags::ParamFlags;
 use crate::row::Row;
 use crate::TypeReader;
 
-#[derive(Copy, Clone, PartialEq, PartialOrd, Eq, Ord)]
+#[derive(Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Debug)]
 pub struct Param(pub Row);
 
 impl Param {

--- a/crates/gen/src/tables/type_ref.rs
+++ b/crates/gen/src/tables/type_ref.rs
@@ -2,7 +2,7 @@ use super::TypeDef;
 use crate::row::Row;
 use crate::TypeReader;
 
-#[derive(Copy, Clone, PartialEq, PartialOrd, Eq, Ord)]
+#[derive(Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Debug)]
 pub struct TypeRef(pub Row);
 
 impl TypeRef {

--- a/crates/gen/src/tables/type_spec.rs
+++ b/crates/gen/src/tables/type_spec.rs
@@ -2,7 +2,7 @@ use crate::blob::Blob;
 use crate::row::Row;
 use crate::TypeReader;
 
-#[derive(Copy, Clone, PartialEq, PartialOrd, Eq, Ord)]
+#[derive(Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Debug)]
 pub struct TypeSpec(pub Row);
 
 impl TypeSpec {


### PR DESCRIPTION
This allows us to remove the custom Debug implementation for ElementType and replace it with a derived Debug as well.

As pinky-promised in the feedback to #231.