### PR TITLE
Reduce cargo-winrt build times

### DIFF
--- a/crates/cargo-winrt/Cargo.toml
+++ b/crates/cargo-winrt/Cargo.toml
@@ -8,7 +8,7 @@ description = "A simple utility for working with WinRT in a Rust project"
 readme = "README.md"
 
 [dependencies]
-structopt = "0.3"
+pico-args = "0.3.2"
 cargo_toml = "0.8"
 tokio = "0.2"
 reqwest = "0.10"

--- a/crates/cargo-winrt/Cargo.toml
+++ b/crates/cargo-winrt/Cargo.toml
@@ -10,12 +10,10 @@ readme = "README.md"
 [dependencies]
 pico-args = "0.3.2"
 cargo_toml = "0.8"
-tokio = "0.2"
-reqwest = "0.10"
-futures = "0.3"
+curl = "0.4.30"
 thiserror = "1.0"
 anyhow = "1.0"
 zip = "0.5"
 console = "0.11"
 serde_json = "1.0"
-once_cell = { version = "1.4", default_features = false }
+once_cell = { version = "1.4" }

--- a/crates/cargo-winrt/Cargo.toml
+++ b/crates/cargo-winrt/Cargo.toml
@@ -13,7 +13,7 @@ cargo_toml = "0.8"
 curl = "0.4.30"
 thiserror = "1.0"
 anyhow = "1.0"
-zip = "0.5"
-console = "0.11"
+zip = { version = "0.5", default-features = false, features = ["deflate"] }
+console = { version = "0.11", default-features = false }
 serde_json = "1.0"
-once_cell = { version = "1.4" }
+once_cell = "1.4"

--- a/crates/cargo-winrt/Cargo.toml
+++ b/crates/cargo-winrt/Cargo.toml
@@ -18,5 +18,4 @@ anyhow = "1.0"
 zip = "0.5"
 console = "0.11"
 serde_json = "1.0"
-serde = { version = "1.0", features = ["derive"] }
 once_cell = { version = "1.4", default_features = false }

--- a/crates/cargo-winrt/src/manifest.rs
+++ b/crates/cargo-winrt/src/manifest.rs
@@ -92,7 +92,7 @@ fn dependency_descriptors_from_metadata(
                     }
                     (None, Some(Value::String(url)), None) => Ok(DependencyDescriptor::Url {
                         name: key,
-                        url, 
+                        url,
                     }),
                     (None, None, Some(Value::String(path))) => Ok(DependencyDescriptor::Local {
                         name: key,

--- a/crates/cargo-winrt/src/manifest.rs
+++ b/crates/cargo-winrt/src/manifest.rs
@@ -92,7 +92,7 @@ fn dependency_descriptors_from_metadata(
                     }
                     (None, Some(Value::String(url)), None) => Ok(DependencyDescriptor::Url {
                         name: key,
-                        url: reqwest::Url::parse(&url)?, // TODO add error context here
+                        url, 
                     }),
                     (None, None, Some(Value::String(path))) => Ok(DependencyDescriptor::Local {
                         name: key,


### PR DESCRIPTION
We'd like to try our best to keep build times low. This change removes many dependencies and keeps the code complexity level fairly consistent. The build time for a release build of `cargo-winrt` goes from 1:28 to 0:44 on my machine. 