### PR TITLE
Add TimeSpan <> std::time::Duration interop

### DIFF
--- a/crates/gen/src/tables/type_def.rs
+++ b/crates/gen/src/tables/type_def.rs
@@ -82,6 +82,8 @@ impl TypeDef {
             true
         } else if flags.interface() {
             false
+        } else if self.name(reader) == ("Windows.Foundation", "TimeSpan") {
+            true
         } else {
             match self.extends(reader).name(reader) {
                 ("System", "ValueType") => self.has_attribute(

--- a/crates/gen/src/types/class.rs
+++ b/crates/gen/src/types/class.rs
@@ -192,12 +192,12 @@ impl Class {
             let into = &base.tokens;
             quote! {
                 impl ::std::convert::From<#from> for #into {
-                    fn from(value: #from) -> #into {
+                    fn from(value: #from) -> Self {
                         ::std::convert::Into::<#into>::into(&value)
                     }
                 }
                 impl ::std::convert::From<&#from> for #into {
-                    fn from(value: &#from) -> #into {
+                    fn from(value: &#from) -> Self {
                         <#from as ::winrt::ComInterface>::query(value)
                     }
                 }

--- a/crates/gen/src/types/method.rs
+++ b/crates/gen/src/types/method.rs
@@ -197,6 +197,7 @@ impl Method {
                 TypeKind::String
                 | TypeKind::Object
                 | TypeKind::Guid
+                | TypeKind::TimeSpan
                 | TypeKind::Class(_)
                 | TypeKind::Interface(_)
                 | TypeKind::Struct(_)

--- a/crates/gen/src/types/object.rs
+++ b/crates/gen/src/types/object.rs
@@ -4,12 +4,12 @@ use quote::quote;
 pub fn to_object_tokens(from: &TokenStream, constraints: &TokenStream) -> TokenStream {
     quote! {
         impl<#constraints> ::std::convert::From<#from> for ::winrt::Object {
-            fn from(value: #from) -> ::winrt::Object {
+            fn from(value: #from) -> Self {
                 unsafe { ::std::mem::transmute(value) }
             }
         }
         impl<#constraints> ::std::convert::From<&#from> for ::winrt::Object {
-            fn from(value: &#from) -> ::winrt::Object {
+            fn from(value: &#from) -> Self {
                 ::std::convert::From::from(::std::clone::Clone::clone(value))
             }
         }

--- a/crates/gen/src/types/param.rs
+++ b/crates/gen/src/types/param.rs
@@ -30,6 +30,7 @@ impl Param {
                 TypeKind::String
                 | TypeKind::Object
                 | TypeKind::Guid
+                | TypeKind::TimeSpan
                 | TypeKind::Class(_)
                 | TypeKind::Interface(_)
                 | TypeKind::Struct(_)
@@ -61,6 +62,7 @@ impl Param {
                 TypeKind::String
                 | TypeKind::Object
                 | TypeKind::Guid
+                | TypeKind::TimeSpan
                 | TypeKind::Class(_)
                 | TypeKind::Interface(_)
                 | TypeKind::Struct(_)
@@ -135,6 +137,7 @@ impl Param {
                     TypeKind::String
                     | TypeKind::Object
                     | TypeKind::Guid
+                    | TypeKind::TimeSpan
                     | TypeKind::Class(_)
                     | TypeKind::Interface(_)
                     | TypeKind::Struct(_)

--- a/crates/gen/src/types/required_interface.rs
+++ b/crates/gen/src/types/required_interface.rs
@@ -144,12 +144,12 @@ impl RequiredInterface {
                 let into = &self.name.tokens;
                 quote! {
                     impl<#constraints> ::std::convert::From<#from> for #into {
-                        fn from(value: #from) -> #into {
+                        fn from(value: #from) -> Self {
                             unsafe { ::std::mem::transmute(value) }
                         }
                     }
                     impl<#constraints> ::std::convert::From<&#from> for #into {
-                        fn from(value: &#from) -> #into {
+                        fn from(value: &#from) -> Self {
                             ::std::convert::From::from(::std::clone::Clone::clone(value))
                         }
                     }
@@ -169,12 +169,12 @@ impl RequiredInterface {
                 let into = &self.name.tokens;
                 quote! {
                     impl<#constraints> ::std::convert::From<#from> for #into {
-                        fn from(value: #from) -> #into {
+                        fn from(value: #from) -> Self {
                             ::std::convert::From::from(&value)
                         }
                     }
                     impl<#constraints> ::std::convert::From<&#from> for #into {
-                        fn from(value: &#from) -> #into {
+                        fn from(value: &#from) -> Self {
                             <#from as ::winrt::ComInterface>::query(value)
                         }
                     }

--- a/crates/gen/src/types/type_kind.rs
+++ b/crates/gen/src/types/type_kind.rs
@@ -25,6 +25,7 @@ pub enum TypeKind {
     String,
     Object,
     Guid,
+    TimeSpan,
     Class(TypeName),
     Interface(TypeName),
     Enum(TypeName),
@@ -51,6 +52,7 @@ impl TypeKind {
             Self::String => "string".to_owned(),
             Self::Object => "cinterface(IInspectable)".to_owned(),
             Self::Guid => "g16".to_owned(),
+            Self::TimeSpan => "struct(Windows.Foundation.TimeSpan;i8)".to_owned(),
             Self::Class(name) => name.class_signature(reader),
             Self::Interface(name) => name.interface_signature(reader),
             Self::Enum(name) => name.enum_signature(reader),
@@ -77,6 +79,7 @@ impl TypeKind {
             Self::String => "String".to_owned(),
             Self::Object => "Object".to_owned(),
             Self::Guid => "Guid".to_owned(),
+            Self::TimeSpan => "Windows.Foundation.TimeSpan".to_owned(),
             Self::Class(name) => name.runtime_name(),
             Self::Interface(name) => name.runtime_name(),
             Self::Enum(name) => name.runtime_name(),
@@ -117,6 +120,8 @@ impl TypeKind {
         let (namespace, name) = type_ref.name(reader);
         if (namespace, name) == ("System", "Guid") {
             TypeKind::Guid
+        } else if (namespace, name) == ("Windows.Foundation", "TimeSpan") {
+            TypeKind::TimeSpan
         } else {
             Self::from_type_def(
                 reader,
@@ -229,6 +234,7 @@ impl TypeKind {
             Self::String => quote! { ::winrt::HString },
             Self::Object => quote! { ::winrt::Object },
             Self::Guid => quote! { ::winrt::Guid },
+            Self::TimeSpan => quote! { ::winrt::TimeSpan },
             Self::Class(name) => name.tokens.clone(),
             Self::Interface(name) => name.tokens.clone(),
             Self::Enum(name) => name.tokens.clone(),
@@ -256,6 +262,7 @@ impl TypeKind {
             Self::F32 => quote! { f32, },
             Self::F64 => quote! { f64, },
             Self::Guid => quote! { ::winrt::Guid, },
+            Self::TimeSpan => quote! { ::winrt::TimeSpan, },
             Self::String => {
                 quote! { <::winrt::HString as ::winrt::AbiTransferable>::Abi, }
             }

--- a/src/hstring.rs
+++ b/src/hstring.rs
@@ -127,7 +127,7 @@ impl std::fmt::Debug for HString {
 }
 
 impl From<&str> for HString {
-    fn from(value: &str) -> HString {
+    fn from(value: &str) -> Self {
         if value.is_empty() {
             return HString::new();
         }
@@ -150,13 +150,13 @@ impl From<&str> for HString {
 }
 
 impl From<String> for HString {
-    fn from(value: String) -> HString {
+    fn from(value: String) -> Self {
         value.as_str().into()
     }
 }
 
 impl From<&String> for HString {
-    fn from(value: &String) -> HString {
+    fn from(value: &String) -> Self {
         value.as_str().into()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,7 @@ mod param;
 mod runtime;
 mod runtime_name;
 mod runtime_type;
+mod time_span;
 
 #[doc(hidden)]
 pub use abi_transferable::AbiTransferable;
@@ -84,6 +85,7 @@ pub use runtime::*;
 pub use runtime_name::RuntimeName;
 #[doc(hidden)]
 pub use runtime_type::RuntimeType;
+pub use time_span::TimeSpan;
 pub use winrt_macros::{build, import};
 
 #[doc(hidden)]

--- a/src/param.rs
+++ b/src/param.rs
@@ -16,25 +16,25 @@ impl<'a, T: AbiTransferable> Param<'a, T> {
 }
 
 impl<'a, T: AbiTransferable> From<T> for Param<'a, T> {
-    fn from(value: T) -> Param<'a, T> {
+    fn from(value: T) -> Self {
         Param::Owned(value)
     }
 }
 
 impl<'a, T: AbiTransferable> From<&'a T> for Param<'a, T> {
-    fn from(value: &'a T) -> Param<'a, T> {
+    fn from(value: &'a T) -> Self {
         Param::Borrowed(value)
     }
 }
 
 impl<'a> From<&'a str> for Param<'a, HString> {
-    fn from(value: &'a str) -> Param<'a, HString> {
+    fn from(value: &'a str) -> Self {
         Param::Owned(value.into())
     }
 }
 
 impl<'a> From<String> for Param<'a, HString> {
-    fn from(value: String) -> Param<'a, HString> {
+    fn from(value: String) -> Self {
         Param::Owned(value.into())
     }
 }

--- a/src/time_span.rs
+++ b/src/time_span.rs
@@ -1,0 +1,49 @@
+use crate::*;
+
+/// Represents a time interval as a signed 64-bit integer value.
+///
+/// TimeSpan represents the WinRT [TimeSpan](https://docs.microsoft.com/en-us/uwp/api/Windows.Foundation.TimeSpan)
+/// struct and provides convertibility with `std::time::Duration`.
+#[repr(C)]
+#[derive(Clone, Default, Debug, PartialEq)]
+pub struct TimeSpan {
+    pub duration: i64,
+}
+
+unsafe impl RuntimeType for TimeSpan {
+    fn signature() -> String {
+        "struct(Windows.Foundation.TimeSpan;i8)".to_owned()
+    }
+}
+
+unsafe impl AbiTransferable for TimeSpan {
+    type Abi = Self;
+
+    fn get_abi(&self) -> Self::Abi {
+        self.clone()
+    }
+
+    fn set_abi(&mut self) -> *mut Self::Abi {
+        self as *mut Self::Abi
+    }
+}
+
+impl From<std::time::Duration> for TimeSpan {
+    fn from(value: std::time::Duration) -> Self {
+        Self {
+            duration: (value.as_nanos() / 100) as i64,
+        }
+    }
+}
+
+impl From<TimeSpan> for std::time::Duration {
+    fn from(value: TimeSpan) -> Self {
+        std::time::Duration::from_nanos((value.duration * 100) as u64)
+    }
+}
+
+impl<'a> Into<Param<'a, TimeSpan>> for std::time::Duration {
+    fn into(self) -> Param<'a, TimeSpan> {
+        Param::Owned(self.into())
+    }
+}

--- a/src/time_span.rs
+++ b/src/time_span.rs
@@ -5,7 +5,7 @@ use crate::*;
 /// TimeSpan represents the WinRT [TimeSpan](https://docs.microsoft.com/en-us/uwp/api/Windows.Foundation.TimeSpan)
 /// struct and provides convertibility with `std::time::Duration`.
 #[repr(C)]
-#[derive(Clone, Default, Debug, PartialEq)]
+#[derive(Copy, Clone, Default, Debug, PartialEq)]
 pub struct TimeSpan {
     pub duration: i64,
 }

--- a/tests/time_span.rs
+++ b/tests/time_span.rs
@@ -1,0 +1,43 @@
+winrt::import!(
+    dependencies
+        nuget: Microsoft.Windows.SDK.Contracts
+        nuget: KennyKerr.Windows.TestWinRT
+    types
+        test_component::*
+        windows::foundation::*
+);
+
+use std::time::Duration;
+use test_component::TestRunner;
+use windows::foundation::*;
+use winrt::TryInto;
+
+#[test]
+fn conversion() -> winrt::Result<()> {
+    let a: winrt::TimeSpan = Duration::from_millis(1234).into();
+    let b = TestRunner::create_time_span(1234)?;
+    assert_eq!(a, b);
+
+    let c: Duration = b.into();
+    assert_eq!(c.as_millis(), 1234);
+
+    Ok(())
+}
+
+#[test]
+fn duration_param() -> winrt::Result<()> {
+    let object = PropertyValue::create_time_span(Duration::from_millis(1234))?;
+    let pv: IPropertyValue = object.try_into()?;
+    assert!(pv.get_time_span()? == Duration::from_millis(1234).into());
+
+    Ok(())
+}
+
+#[test]
+fn time_span_param() -> winrt::Result<()> {
+    let object = PropertyValue::create_time_span(TestRunner::create_time_span(1234)?)?;
+    let pv: IPropertyValue = object.try_into()?;
+    assert!(pv.get_time_span()? == Duration::from_millis(1234).into());
+
+    Ok(())
+}


### PR DESCRIPTION
This update elevates `Windows.Foundation.TimeSpan` to a well-known type within the `winrt` crate rather than simply being generated in order to enable improved usability and interop with Rust's `std::time::Duration`. 

You can now pass a `Duration` to any input parameter expecting a `TimeSpan` and can use `into()` to convert between the types.

Fixes #90