### PR TITLE
Update cargo-winrt output to better match cargo's style

### DIFF
--- a/crates/cargo-winrt/src/main.rs
+++ b/crates/cargo-winrt/src/main.rs
@@ -11,6 +11,7 @@ use curl::easy::Easy;
 use std::ffi::OsString;
 use std::io::Read;
 use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
 
 fn main() {
     if let Err(i) = run() {
@@ -169,16 +170,37 @@ fn verbose() -> bool {
     VERBOSITY.get().copied().unwrap_or(false)
 }
 
-macro_rules! debug {
-    ($($arg:tt)*) => {
-        if verbose() {
-            eprintln!("\t{}", format!($($arg)*));
-        }
-    };
+/// Formats the elapsed time to match Cargo's output.
+fn elapsed(duration: Duration) -> String {
+    let secs = duration.as_secs();
+
+    if secs >= 60 {
+        format!("{}m {:02}s", secs / 60, secs % 60)
+    } else {
+        format!("{}.{:02}s", secs, duration.subsec_nanos() / 10_000_000)
+    }
+}
+
+fn print_status<D>(status: &str, message: D)
+where
+    D: std::fmt::Display,
+{
+    println!("{:>12} {}", console::style(status).green().bold(), message);
+}
+
+fn print_verbose_status<D>(status: &str, message: D)
+where
+    D: std::fmt::Display,
+{
+    if verbose() {
+        eprintln!("{:>12} {}", console::style(status).green().bold(), message);
+    }
 }
 
 impl Install {
     fn perform(&self) -> anyhow::Result<()> {
+        let start_time = Instant::now();
+
         let _ = VERBOSITY.set(self.verbose);
         let manifest = cargo::package_manifest()?;
         let local_dependencies = manifest.local_dependencies()?;
@@ -186,15 +208,15 @@ impl Install {
             self.install_from_manifest(dep_manifest)?;
         }
         self.install_from_manifest(manifest)?;
+
+        let time_elapsed = elapsed(start_time.elapsed());
+        print_status("Finished", &format!("in {}", time_elapsed));
+
         Ok(())
     }
 
     fn install_from_manifest(&self, manifest: Manifest) -> anyhow::Result<()> {
-        debug!(
-            "{} dependencies for {}",
-            console::style("Resolving").green().bold(),
-            manifest.package_name()
-        );
+        print_verbose_status("Resolving", manifest.package_name());
         let deps = manifest.get_dependency_descriptors()?;
         self.ensure_dependencies(deps)
     }
@@ -215,10 +237,10 @@ impl Install {
                 })
                 .collect::<anyhow::Result<Vec<DependencyDescriptor>>>()?
         };
-        debug!(
-            "{} {} nuget dependencies",
-            console::style("Installing").green().bold(),
-            dependency_descriptors.len()
+
+        print_verbose_status(
+            "Installing",
+            format_args!("{} nuget dependencies", dependency_descriptors.len()),
         );
 
         let deps = self.get_dependencies(dependency_descriptors)?;
@@ -234,11 +256,7 @@ impl Install {
     ) -> anyhow::Result<Vec<ResolvedDependency>> {
         deps.into_iter()
             .map(|dep| {
-                println!(
-                    "\t{}: {}",
-                    console::style("Fetching").green().bold(),
-                    dep.name()
-                );
+                print_status("Fetching", dep.name());
                 let raw = dep.get()?;
                 Ok(ResolvedDependency::new(dep, raw)?)
             })
@@ -329,12 +347,12 @@ fn try_download(url: String, recursion_amount: u8) -> anyhow::Result<Vec<u8>> {
                 true
             })
             .unwrap();
-        debug!(" making request to {}", url);
+        print_verbose_status("Requesting", &url);
         transfer.perform()?;
     }
     match status.expect("HTTP request did not have a status code") {
         200u16 => {
-            debug!(" retrieved data from {}", url);
+            print_verbose_status("Retrieved", format_args!("data from {}", url));
             let mut bytes = Vec::new();
             {
                 let mut transfer = handle.transfer();
@@ -380,7 +398,7 @@ enum RawNuget {
 
 impl RawNuget {
     fn contents(&self) -> anyhow::Result<(Vec<Winmd>, Vec<Dll>)> {
-        debug!(" starting extraction of '{}'", self.name());
+        print_verbose_status("Starting", format_args!("extraction of '{}'", self.name()));
         match self {
             RawNuget::Zipped { bytes, .. } => unzip(bytes),
             RawNuget::Unzipped { path, .. } => unpack(path),
@@ -455,7 +473,7 @@ fn extract_files<F: Read>(
     winmds: &mut Vec<Winmd>,
     dlls: &mut Vec<Dll>,
 ) -> anyhow::Result<()> {
-    debug!("   searching zip file: {:?}", path.display());
+    print_verbose_status("Searching", format_args!("zip file: {}", path.display()));
     match path.extension() {
         Some(e)
             if e == "winmd" && {
@@ -467,7 +485,7 @@ fn extract_files<F: Read>(
                 .file_name()
                 .context("windmd file name is not utf-8")?
                 .to_owned();
-            debug!(" {} winmd file {:?}", console::style("found").green(), name);
+            print_verbose_status("Found", format_args!("winmd file: {:?}", name));
             let mut contents = Vec::with_capacity(file_size as usize);
 
             if let Err(e) = file.read_to_end(&mut contents) {
@@ -507,13 +525,17 @@ fn extract_files<F: Read>(
                     ));
                 }
             };
-            debug!(
-                "{} dll {:?} with arch {:?} at path {}",
-                console::style("found").green(),
-                name,
-                arch,
-                path.display()
+
+            print_verbose_status(
+                "Found",
+                &format_args!(
+                    "dll {:?} with arch {:?} at path {}",
+                    name,
+                    arch,
+                    path.display()
+                ),
             );
+
             let mut contents = Vec::with_capacity(file_size as usize);
 
             if let Err(e) = file.read_to_end(&mut contents) {
@@ -558,12 +580,15 @@ impl ResolvedDependency {
     }
 
     fn save(self) -> anyhow::Result<()> {
-        debug!(
-            "{} {} winmd files and {} dlls",
-            console::style("Saving").green().bold(),
-            self.winmds().len(),
-            self.dlls().len(),
+        print_verbose_status(
+            "Saving",
+            format_args!(
+                "{} winmd files and {} dlls",
+                self.winmds().len(),
+                self.dlls().len()
+            ),
         );
+
         let dep_directory = self.descriptor.directory_path()?;
         // create the dependency directory
         if !dep_directory.exists() {
@@ -572,19 +597,21 @@ impl ResolvedDependency {
         }
 
         for winmd in self.winmds() {
-            debug!(
-                "writing winmd file {:?} into {}",
-                winmd.name,
-                dep_directory.display()
+            print_verbose_status(
+                "Writing",
+                format_args!(
+                    "winmd file {:?} into {}",
+                    winmd.name,
+                    dep_directory.display()
+                ),
             );
             winmd.write(&dep_directory)?;
         }
 
         for dll in self.dlls() {
-            debug!(
-                "writing dll file {:?} into {}",
-                dll.name,
-                dep_directory.display()
+            print_verbose_status(
+                "Writing",
+                format_args!("dll file {:?} into {}", dll.name, dep_directory.display()),
             );
             dll.write(&dep_directory).unwrap();
         }
@@ -618,7 +645,7 @@ impl Dll {
     fn write(&self, dir: &Path) -> anyhow::Result<()> {
         let proper_arch = ARCHES.contains(&&*self.arch.to_string_lossy());
         if !proper_arch {
-            debug!("   not creating symlink for {:?} because of differing architecture to host architecture: {:?} not in {:?}", self.name, self.arch, ARCHES);
+            print_verbose_status("", format_args!("   not creating symlink for {:?} because of differing architecture to host architecture: {:?} not in {:?}", self.name, self.arch, ARCHES));
             return Ok(());
         }
         let path = dir.join(&self.name);
@@ -631,18 +658,24 @@ impl Dll {
             std::fs::create_dir_all(&profile_path)?;
             let dll_path = profile_path.join(&self.name);
             if std::fs::read_link(&dll_path).is_err() {
-                debug!(
-                    "   creating symlink for {:?} in {}: '{}' <-> '{}'",
-                    self.name,
-                    profile,
-                    path.display(),
-                    dll_path.display()
+                print_verbose_status(
+                    "Creating",
+                    format_args!(
+                        "symlink for {:?} in {}: '{}' <-> '{}'",
+                        self.name,
+                        profile,
+                        path.display(),
+                        dll_path.display()
+                    ),
                 );
                 std::os::windows::fs::symlink_file(&path, dll_path)?;
             } else {
-                debug!(
-                    "   not creating symlink for {:?} in {} because it already exists",
-                    self.name, profile
+                print_verbose_status(
+                    "",
+                    format_args!(
+                        "   not creating symlink for {:?} in {} because it already exists",
+                        self.name, profile
+                    ),
                 );
             }
         }


### PR DESCRIPTION
Add print_status and print_verbose_status methods with consistent justified formatting.

As specified in #247 .

![cargo_winrt_output](https://user-images.githubusercontent.com/308981/86963739-d62f7900-c119-11ea-9bd1-08de9c480139.PNG)
