### PR TITLE
Support for creating composable types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,5 +29,5 @@ targets = ["x86_64-pc-windows-msvc", "i686-pc-windows-msvc"]
 
 [package.metadata.winrt.dependencies]
 "Microsoft.Windows.SDK.Contracts" = "10.0.19041.1"
-"KennyKerr.Windows.TestWinRT" = "1.0.14"
+"KennyKerr.Windows.TestWinRT" = "1.0.15"
 "Microsoft.AI.MachineLearning" = "1.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,5 +29,5 @@ targets = ["x86_64-pc-windows-msvc", "i686-pc-windows-msvc"]
 
 [package.metadata.winrt.dependencies]
 "Microsoft.Windows.SDK.Contracts" = "10.0.19041.1"
-"KennyKerr.Windows.TestWinRT" = "1.0.15"
+"KennyKerr.Windows.TestWinRT" = "1.0.16"
 "Microsoft.AI.MachineLearning" = "1.3.0"

--- a/crates/gen/macros/src/lib.rs
+++ b/crates/gen/macros/src/lib.rs
@@ -60,7 +60,7 @@ pub fn type_code(args: TokenStream, input: TokenStream) -> TokenStream {
                 let code = (code & ((1 << #bits) - 1), (code >> #bits) - 1);
                 match code.0 {
                     #decodes
-                    _ => panic!(),
+                    _ => panic!("Failed to decode type code"),
                 }
             }
         }

--- a/crates/gen/src/codes.rs
+++ b/crates/gen/src/codes.rs
@@ -60,7 +60,7 @@ impl TypeDefOrRef {
         match self {
             TypeDefOrRef::TypeDef(value) => value.name(reader),
             TypeDefOrRef::TypeRef(value) => value.name(reader),
-            TypeDefOrRef::TypeSpec(_) => panic!(),
+            TypeDefOrRef::TypeSpec(_) => panic!("Expected a TypeDef or TypeRef"),
         }
     }
 
@@ -68,7 +68,7 @@ impl TypeDefOrRef {
         match self {
             Self::TypeDef(value) => *value,
             Self::TypeRef(value) => value.resolve(reader),
-            Self::TypeSpec(_) => panic!(),
+            Self::TypeSpec(_) => panic!("Expected a TypeDef or TypeRef"),
         }
     }
 }

--- a/crates/gen/src/tables/attribute.rs
+++ b/crates/gen/src/tables/attribute.rs
@@ -25,7 +25,7 @@ impl Attribute {
             AttributeType::MemberRef(method) => match method.parent(reader) {
                 MemberRefParent::TypeDef(parent) => parent.name(reader),
                 MemberRefParent::TypeRef(parent) => parent.name(reader),
-                _ => panic!(),
+                _ => panic!("Expected a TypeDef or TypeRef"),
             },
         }
     }
@@ -60,7 +60,7 @@ impl Attribute {
                     let (namespace, type_name) = match type_def_or_ref {
                         TypeDefOrRef::TypeDef(type_def) => type_def.name(reader),
                         TypeDefOrRef::TypeRef(type_ref) => type_ref.name(reader),
-                        _ => panic!("Expected a TypeDef or TypeRef!"),
+                        _ => panic!("Expected a TypeDef or TypeRef"),
                     };
 
                     if namespace == "System" && type_name == "Type" {
@@ -82,7 +82,7 @@ impl Attribute {
                         read_enum(&e.underlying_type, &mut values)
                     }
                 }
-                _ => panic!(),
+                _ => panic!("Unexpected fixed attribute argument type"),
             };
 
             args.push((String::new(), arg));
@@ -104,13 +104,7 @@ impl Attribute {
                         reader.resolve_type_def((&name[0..index], &name[index + 1..])),
                     )
                 }
-                // 0x55 => {
-                //     let name = values.read_str();
-                //     let index = name.rfind('.').unwrap();
-                //     let def = reader.resolve_type_def((&name[0..index], &name[index + 1..]));
-                //     def.fields(reader).next().unwrap().
-                // }
-                _ => panic!(),
+                _ => panic!("Unexpected named attribute argument type"),
             };
             args.push((name, arg));
         }

--- a/crates/gen/src/type_reader.rs
+++ b/crates/gen/src/type_reader.rs
@@ -134,7 +134,7 @@ impl TypeReader {
             0..=3 => (initial_byte & 0x7f, 1),
             4..=5 => (initial_byte & 0x3f, 2),
             6 => (initial_byte & 0x1f, 4),
-            _ => panic!(),
+            _ => panic!("Invalid blob size"),
         };
         for byte in &file.bytes[offset + 1..offset + blob_size_bytes] {
             blob_size = blob_size.checked_shl(8).unwrap_or(0) + byte;

--- a/crates/gen/src/types/class.rs
+++ b/crates/gen/src/types/class.rs
@@ -70,25 +70,26 @@ impl Class {
                     }
                 }
                 ("Windows.Foundation.Metadata", "ComposableAttribute") => {
+                    // One of the arguments is a CompositionType enum and the Public variant
+                    // has a value of 2 as a signed 32-bit integer.
                     for (_name, arg) in attribute.args(reader) {
-                        if let AttributeArg::I32(value) = arg {
-                            if value == 2 {
-                                // public
-                                let mut interface = RequiredInterface::from_type_def(
-                                    reader,
-                                    attribute_factory(reader, attribute).unwrap(),
-                                    &name.namespace,
-                                );
-                                interface.kind = InterfaceKind::Composable;
-                                interfaces.push(interface);
-                            }
+                        if let AttributeArg::I32(2) = arg {
+                            let mut interface = RequiredInterface::from_type_def(
+                                reader,
+                                attribute_factory(reader, attribute).unwrap(),
+                                &name.namespace,
+                            );
+                            interface.kind = InterfaceKind::Composable;
+                            interfaces.push(interface);
                         }
                     }
                 }
                 ("Windows.Foundation.Metadata", "MarshalingBehaviorAttribute") => {
+                    // The only argument is a MarshalingType enum and the Agile variant
+                    // has a value of 2 as a signed 32-bit integer.
                     let args = attribute.args(reader);
                     if let AttributeArg::I32(2) = args[0].1 {
-                        is_agile = true; // MarshalingType.Agile
+                        is_agile = true;
                     }
                 }
                 _ => {}

--- a/crates/gen/src/types/class.rs
+++ b/crates/gen/src/types/class.rs
@@ -69,9 +69,25 @@ impl Class {
                         None => default_constructor = true,
                     }
                 }
+                ("Windows.Foundation.Metadata", "ComposableAttribute") => {
+                    for (_name, arg) in attribute.args(reader) {
+                        if let AttributeArg::I32(value) = arg {
+                            if value == 2 {
+                                // public
+                                let mut interface = RequiredInterface::from_type_def(
+                                    reader,
+                                    attribute_factory(reader, attribute).unwrap(),
+                                    &name.namespace,
+                                );
+                                interface.kind = InterfaceKind::Composable;
+                                interfaces.push(interface);
+                            }
+                        }
+                    }
+                }
                 ("Windows.Foundation.Metadata", "MarshalingBehaviorAttribute") => {
                     let args = attribute.args(reader);
-                    if let AttributeArg::I16(2) = args[0].1 {
+                    if let AttributeArg::I32(2) = args[0].1 {
                         is_agile = true; // MarshalingType.Agile
                     }
                 }

--- a/crates/gen/src/types/class.rs
+++ b/crates/gen/src/types/class.rs
@@ -87,8 +87,9 @@ impl Class {
                 ("Windows.Foundation.Metadata", "MarshalingBehaviorAttribute") => {
                     // The only argument is a MarshalingType enum and the Agile variant
                     // has a value of 2 as a signed 32-bit integer.
-                    let args = attribute.args(reader);
-                    if let AttributeArg::I32(2) = args[0].1 {
+                    let (_name, arg) = &attribute.args(reader)[0];
+                    
+                    if let AttributeArg::I32(2) = arg {
                         is_agile = true;
                     }
                 }

--- a/crates/gen/src/types/class.rs
+++ b/crates/gen/src/types/class.rs
@@ -88,7 +88,7 @@ impl Class {
                     // The only argument is a MarshalingType enum and the Agile variant
                     // has a value of 2 as a signed 32-bit integer.
                     let (_name, arg) = &attribute.args(reader)[0];
-                    
+
                     if let AttributeArg::I32(2) = arg {
                         is_agile = true;
                     }

--- a/crates/gen/src/types/enum.rs
+++ b/crates/gen/src/types/enum.rs
@@ -24,8 +24,6 @@ impl Enum {
         let signature = name.enum_signature(reader);
         let mut fields = Vec::new();
 
-        let mut underlying_type = None;
-
         for field in name.def.fields(reader) {
             for constant in field.constants(reader) {
                 let name = field.name(reader).to_string();
@@ -37,21 +35,20 @@ impl Enum {
                     _ => panic!("Enum::from_type_def"),
                 };
 
-                let flags = field.flags(reader);
-                if underlying_type.is_none() && flags.is_static() && flags.literal() {
-                    let field_type = ElementType::from_blob(&mut field.sig(reader));
-                    underlying_type = Some(field_type);
-                }
-
                 fields.push((name, value));
             }
         }
+
+        let underlying_type = match fields[0].1 {
+            EnumConstant::U32(_) => ElementType::U4,
+            EnumConstant::I32(_) => ElementType::I4,
+        };
 
         Self {
             name,
             fields,
             signature,
-            underlying_type: underlying_type.expect("Enum must have an underlying type"),
+            underlying_type,
         }
     }
 

--- a/crates/gen/src/types/futures.rs
+++ b/crates/gen/src/types/futures.rs
@@ -62,7 +62,7 @@ fn to_async_tokens(
         AsyncKind::ActionWithProgress => quote! { AsyncActionWithProgressCompletedHandler },
         AsyncKind::Operation => quote! { AsyncOperationCompletedHandler },
         AsyncKind::OperationWithProgress => quote! { AsyncOperationWithProgressCompletedHandler },
-        _ => panic!(),
+        _ => panic!("Unexpected AsyncKind"),
     };
 
     let constraints = &self_name.constraints;

--- a/crates/gen/src/types/method.rs
+++ b/crates/gen/src/types/method.rs
@@ -165,113 +165,14 @@ impl Method {
         }
     }
 
-    fn to_param_tokens(&self) -> TokenStream {
-        TokenStream::from_iter(
-            self.params
-                .iter()
-                .enumerate()
-                .map(|(position, param)| param.to_tokens(position)),
-        )
-    }
-
-    fn to_arg_tokens(&self) -> TokenStream {
-        TokenStream::from_iter(self.params.iter().map(|param| {
-            let name = format_ident(&param.name);
-            quote! { #name, }
-        }))
-    }
-
-    fn to_constraint_tokens(&self) -> TokenStream {
-        let mut tokens = Vec::new();
-
-        for (position, param) in self.params.iter().enumerate() {
-            if !param.input || param.array {
-                continue;
-            }
-
-            match param.kind {
-                TypeKind::String
-                | TypeKind::Object
-                | TypeKind::Guid
-                | TypeKind::TimeSpan
-                | TypeKind::Class(_)
-                | TypeKind::Interface(_)
-                | TypeKind::Struct(_)
-                | TypeKind::Delegate(_)
-                | TypeKind::Generic(_) => {
-                    let name = quote::format_ident!("T{}__", position);
-                    let into = param.kind.to_tokens();
-                    tokens.push(quote! { #name: ::std::convert::Into<::winrt::Param<'a, #into>>, });
-                }
-                _ => {}
-            };
-        }
-
-        if !tokens.is_empty() {
-            tokens.insert(0, quote! { 'a, });
-        }
-
-        TokenStream::from_iter(tokens)
-    }
-
-    fn to_composable_param_tokens(&self) -> TokenStream {
-        TokenStream::from_iter(
-            self.params
-                .iter()
-                .take(self.params.len() - 2)
-                .enumerate()
-                .map(|(position, param)| param.to_tokens(position)),
-        )
-    }
-
-    fn to_composable_arg_tokens(&self) -> TokenStream {
-        TokenStream::from_iter(self.params.iter().take(self.params.len() - 2).map(|param| {
-            let name = format_ident(&param.name);
-            quote! { #name, }
-        }))
-    }
-
-    fn to_composable_constraint_tokens(&self) -> TokenStream {
-        let mut tokens = Vec::new();
-
-        for (position, param) in self.params.iter().take(self.params.len() - 2).enumerate() {
-            if !param.input || param.array {
-                continue;
-            }
-
-            match param.kind {
-                TypeKind::String
-                | TypeKind::Object
-                | TypeKind::Guid
-                | TypeKind::TimeSpan
-                | TypeKind::Class(_)
-                | TypeKind::Interface(_)
-                | TypeKind::Struct(_)
-                | TypeKind::Delegate(_)
-                | TypeKind::Generic(_) => {
-                    let name = quote::format_ident!("T{}__", position);
-                    let into = param.kind.to_tokens();
-                    tokens.push(quote! { #name: ::std::convert::Into<::winrt::Param<'a, #into>>, });
-                }
-                _ => {}
-            };
-        }
-
-        if !tokens.is_empty() {
-            tokens.insert(0, quote! { 'a, });
-        }
-
-        TokenStream::from_iter(tokens)
-    }
-
     fn to_abi_arg_tokens(&self) -> TokenStream {
         TokenStream::from_iter(self.params.iter().map(|param| param.to_abi_arg_tokens()))
     }
 
     pub fn to_default_tokens(&self) -> TokenStream {
         let method_name = format_ident(&self.name);
-        let params = self.to_param_tokens();
-        let constraints = self.to_constraint_tokens();
+        let params = to_param_tokens(&self.params);
+        let constraints = to_constraint_tokens(&self.params);
         let args = self.to_abi_arg_tokens();
 
         if let Some(return_type) = &self.return_type {
@@ -302,9 +203,9 @@ impl Method {
 
     pub fn to_non_default_tokens(&self, interface: &RequiredInterface) -> TokenStream {
         let method_name = format_ident(&self.name);
-        let params = self.to_param_tokens();
-        let constraints = self.to_constraint_tokens();
-        let args = self.to_arg_tokens();
+        let params = to_param_tokens(&self.params);
+        let constraints = to_constraint_tokens(&self.params);
+        let args = to_arg_tokens(&self.params);
         let interface = &interface.name.tokens;
 
         let return_type = if let Some(return_type) = &self.return_type {
@@ -322,9 +223,9 @@ impl Method {
 
     pub fn to_static_tokens(&self, interface: &RequiredInterface) -> TokenStream {
         let method_name = format_ident(&self.name);
-        let params = self.to_param_tokens();
-        let constraints = self.to_constraint_tokens();
-        let args = self.to_arg_tokens();
+        let params = to_param_tokens(&self.params);
+        let constraints = to_constraint_tokens(&self.params);
+        let args = to_arg_tokens(&self.params);
         let interface = &interface.name.tokens;
 
         let return_type = if let Some(return_type) = &self.return_type {
@@ -357,9 +258,10 @@ impl Method {
                 }
             }
         } else {
-            let params = self.to_composable_param_tokens();
-            let constraints = self.to_composable_constraint_tokens();
-            let args = self.to_composable_arg_tokens();
+            let params = &self.params[..self.params.len() - 2];
+            let constraints = to_constraint_tokens(params);
+            let args = to_arg_tokens(params);
+            let params = to_param_tokens(params);
 
             quote! {
                 pub fn #method_name<#constraints>(#params) -> ::winrt::Result<#return_type> {
@@ -368,6 +270,55 @@ impl Method {
             }
         }
     }
+}
+
+fn to_param_tokens(params: &[Param]) -> TokenStream {
+    TokenStream::from_iter(
+        params
+            .iter()
+            .enumerate()
+            .map(|(position, param)| param.to_tokens(position)),
+    )
+}
+
+fn to_arg_tokens(params: &[Param]) -> TokenStream {
+    TokenStream::from_iter(params.iter().map(|param| {
+        let name = format_ident(&param.name);
+        quote! { #name, }
+    }))
+}
+
+fn to_constraint_tokens(params: &[Param]) -> TokenStream {
+    let mut tokens = Vec::new();
+
+    for (position, param) in params.iter().enumerate() {
+        if !param.input || param.array {
+            continue;
+        }
+
+        match param.kind {
+            TypeKind::String
+            | TypeKind::Object
+            | TypeKind::Guid
+            | TypeKind::TimeSpan
+            | TypeKind::Class(_)
+            | TypeKind::Interface(_)
+            | TypeKind::Struct(_)
+            | TypeKind::Delegate(_)
+            | TypeKind::Generic(_) => {
+                let name = quote::format_ident!("T{}__", position);
+                let into = param.kind.to_tokens();
+                tokens.push(quote! { #name: ::std::convert::Into<::winrt::Param<'a, #into>>, });
+            }
+            _ => {}
+        };
+    }
+
+    if !tokens.is_empty() {
+        tokens.insert(0, quote! { 'a, });
+    }
+
+    TokenStream::from_iter(tokens)
 }
 
 #[cfg(test)]

--- a/crates/gen/src/types/required_interface.rs
+++ b/crates/gen/src/types/required_interface.rs
@@ -215,6 +215,7 @@ pub fn to_method_tokens(interfaces: &Vec<RequiredInterface>) -> TokenStream {
                     method.to_non_default_tokens(interface)
                 }
                 InterfaceKind::Statics => method.to_static_tokens(interface),
+                InterfaceKind::Composable => method.to_composable_tokens(interface),
             });
         }
     }

--- a/crates/gen/src/types/required_interface.rs
+++ b/crates/gen/src/types/required_interface.rs
@@ -20,6 +20,7 @@ pub enum InterfaceKind {
     NonDefault,
     Overrides,
     Statics,
+    Composable,
 }
 
 impl RequiredInterface {

--- a/tests/composable.rs
+++ b/tests/composable.rs
@@ -11,5 +11,11 @@ use winrt::*;
 
 #[test]
 fn composable() -> Result<()> {
+    let c = Composable::new()?;
+    assert_eq!(c.value()?, 0);
+
+    let c = Composable::create_instance2(123)?;
+    assert_eq!(c.value()?, 123);
+
     Ok(())
 }

--- a/tests/composable.rs
+++ b/tests/composable.rs
@@ -14,7 +14,7 @@ fn composable() -> Result<()> {
     let c = Composable::new()?;
     assert_eq!(c.value()?, 0);
 
-    let c = Composable::create_instance2(123)?;
+    let c = Composable::create_with_value(123)?;
     assert_eq!(c.value()?, 123);
 
     Ok(())

--- a/tests/composable.rs
+++ b/tests/composable.rs
@@ -1,0 +1,17 @@
+import!(
+    dependencies
+        nuget: Microsoft.Windows.SDK.Contracts
+        nuget: KennyKerr.Windows.TestWinRT
+    types
+        test_component::Composable
+);
+
+use test_component::Composable;
+use winrt::*;
+
+#[test]
+fn composable() -> Result<()> {
+
+
+    Ok(())
+}

--- a/tests/composable.rs
+++ b/tests/composable.rs
@@ -11,7 +11,5 @@ use winrt::*;
 
 #[test]
 fn composable() -> Result<()> {
-
-
     Ok(())
 }

--- a/tests/xaml.rs
+++ b/tests/xaml.rs
@@ -1,14 +1,14 @@
-winrt::import!(
-    dependencies
-        os
-    types
-        windows::ui::xaml::*
-);
-#[test]
-fn xaml() -> winrt::Result<()> {
-    use winrt::ComInterface;
-    let app = windows::ui::xaml::Application::default();
-    assert!(app.is_null());
+// winrt::import!(
+//     dependencies
+//         os
+//     types
+//         windows::ui::xaml::*
+// );
+// #[test]
+// fn xaml() -> winrt::Result<()> {
+//     use winrt::ComInterface;
+//     let app = windows::ui::xaml::Application::default();
+//     assert!(app.is_null());
 
-    Ok(())
-}
+//     Ok(())
+// }

--- a/tests/xaml.rs
+++ b/tests/xaml.rs
@@ -1,14 +1,36 @@
-// winrt::import!(
-//     dependencies
-//         os
-//     types
-//         windows::ui::xaml::*
-// );
-// #[test]
-// fn xaml() -> winrt::Result<()> {
-//     use winrt::ComInterface;
-//     let app = windows::ui::xaml::Application::default();
-//     assert!(app.is_null());
+winrt::import!(
+    dependencies
+        os
+    types
+        windows::ui::xaml::*
+);
 
-//     Ok(())
-// }
+use windows::ui::xaml::*;
+use winrt::ComInterface;
+
+#[test]
+fn xaml() -> winrt::Result<()> {
+    let app = Application::default();
+    assert_eq!(app.is_null(), true);
+
+    let app = Application::new()?;
+    assert_eq!(app.is_null(), false);
+
+    // The DataTemplateKey "constructors" fail because they're not
+    // satisfying preconditions, but they still validate that the
+    // composable constructors are being generated correctly.
+
+    assert_eq!(
+        DataTemplateKey::new().unwrap_err().code(),
+        winrt::ErrorCode(0x8001_010E) // wrong thread
+    );
+
+    assert_eq!(
+        DataTemplateKey::create_instance_with_type(winrt::Object::default())
+            .unwrap_err()
+            .code(),
+        winrt::ErrorCode(0x8007_0057) // invalid argument
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Fixes #148

This update adds support for creating composable types when a derived type isn't necessarily needed. This just makes early adoption of Xaml easier. 

Also fixed a few metadata parsing bugs.