### PR TITLE
Fix named arguments in attribute parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,5 +30,5 @@ targets = ["x86_64-pc-windows-msvc", "i686-pc-windows-msvc"]
 
 [package.metadata.winrt.dependencies]
 "Microsoft.Windows.SDK.Contracts" = "10.0.19041.1"
-"KennyKerr.Windows.TestWinRT" = "1.0.16"
+"KennyKerr.Windows.TestWinRT" = "1.0.17"
 "Microsoft.AI.MachineLearning" = "1.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ sha1 = "0.6.0"
 [dev-dependencies]
 doc-comment = "0.3"
 futures = "0.3"
+winrt_gen = { path = "crates/gen" }
 
 [workspace]
 members = [

--- a/crates/gen/src/lib.rs
+++ b/crates/gen/src/lib.rs
@@ -16,6 +16,7 @@ mod types;
 pub mod dependencies;
 pub mod load_winmd;
 pub use file::WinmdFile;
+pub use tables::AttributeArg;
 pub use type_limits::{NamespaceTypes, TypeLimit, TypeLimits};
 pub use type_reader::TypeReader;
 pub use type_stage::TypeStage;

--- a/crates/gen/src/tables/attribute.rs
+++ b/crates/gen/src/tables/attribute.rs
@@ -92,8 +92,14 @@ impl Attribute {
         args.reserve(named_arg_count as usize);
 
         for _ in 0..named_arg_count {
+            let id = values.read_u8();
+            debug_assert!(
+                id == 0x53 || id == 0x54,
+                "A NamedArg must start with an id of 0x53 (Field) or 0x54 (Property)"
+            );
+            let arg_type = values.read_u8();
             let name = values.read_str().to_string();
-            let arg = match values.read_u8() {
+            let arg = match arg_type {
                 0x02 => AttributeArg::Bool(values.read_u8() != 0),
                 0x08 => AttributeArg::I32(values.read_i32()),
                 0x0E => AttributeArg::String(values.read_str().to_string()),

--- a/tests/custom_attribute.rs
+++ b/tests/custom_attribute.rs
@@ -1,0 +1,86 @@
+// This is used to make sure our dependencies are picked up by cargo winrt
+import!(
+    dependencies
+        nuget: Microsoft.Windows.SDK.Contracts
+        nuget: KennyKerr.Windows.TestWinRT
+    types
+        test_component::*
+        windows::foundation::*
+);
+
+use std::path::{Path, PathBuf};
+use winrt::*;
+use winrt_gen::{load_winmd, AttributeArg, TypeReader};
+
+fn find_winmds<P: AsRef<Path>>(directory: P) -> Vec<PathBuf> {
+    let mut result = Vec::new();
+    for entry in std::fs::read_dir(directory).unwrap() {
+        let entry = entry.unwrap();
+        let path = entry.path();
+        if path.is_file() {
+            if let Some(ext) = path.extension() {
+                if ext == "winmd" {
+                    result.push(path.clone());
+                }
+            }
+        }
+    }
+    result
+}
+
+#[test]
+fn named_arguments() -> Result<()> {
+    // Get our WinMD files from the target directory
+    let files = {
+        let mut files = Vec::new();
+        let paths = [
+            "target/nuget/Microsoft.Windows.SDK.Contracts",
+            "target/nuget/KennyKerr.Windows.TestWinRT",
+        ];
+        for path in &paths {
+            files.append(&mut find_winmds(path));
+        }
+        files
+    };
+    let winmds = load_winmd::from_files(files);
+
+    let reader = TypeReader::new(winmds);
+    let type_def = reader.resolve_type_def(("TestComponent", "TestRunner"));
+
+    // TestRunner should have a custom attribute on it
+    let mut some_string = 0;
+    let mut some_int = 0;
+    let mut some_bool = 0;
+    for attribute in type_def.attributes(&reader) {
+        match attribute.name(&reader) {
+            ("TestComponent", "CustomTestAttribute") => {
+                for (name, arg) in attribute.args(&reader) {
+                    match (&name as &str, &arg) {
+                        ("SomeString", AttributeArg::String(value)) => {
+                            assert_eq!(value, "Hello, World!");
+                            some_string += 1;
+                        }
+                        ("SomeInt", AttributeArg::I32(value)) => {
+                            assert_eq!(*value, 1975);
+                            some_int += 1;
+                        }
+                        ("SomeBool", AttributeArg::Bool(value)) => {
+                            assert_eq!(*value, true);
+                            some_bool += 1;
+                        }
+                        _ => panic!(
+                            "Unexpected named argument! Name: '{}'  Arg: {:?}",
+                            name, arg
+                        ),
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    assert_eq!(some_string, 1);
+    assert_eq!(some_int, 1);
+    assert_eq!(some_bool, 1);
+
+    Ok(())
+}

--- a/tests/custom_attribute.rs
+++ b/tests/custom_attribute.rs
@@ -1,13 +1,3 @@
-// This is used to make sure our dependencies are picked up by cargo winrt
-import!(
-    dependencies
-        nuget: Microsoft.Windows.SDK.Contracts
-        nuget: KennyKerr.Windows.TestWinRT
-    types
-        test_component::*
-        windows::foundation::*
-);
-
 use std::path::{Path, PathBuf};
 use winrt::*;
 use winrt_gen::{load_winmd, AttributeArg, TypeReader};


### PR DESCRIPTION
Currently it seems that named arguments in the attribute parsing isn't working properly. I don't think it comes up in any of the Windows APIs, but I discovered it while messing with custom attributes.

It appears that the first byte is the identification, which must be either 0x53 or 0x54 according to the spec:

```
9. The following rules apply to the structure of NamedArg (§II.23.3):
    *  A NamedArg shall begin with the single byte FIELD (0x53) or PROPERTY (0x54) for identification [ERROR]
```
Page 217 (243 in the [pdf](https://www.ecma-international.org/publications/files/ECMA-ST/ECMA-335.pdf))

The next byte is the argument type, followed by the name.

Unfortunately I'm not sure what's the best way to test this as-is. I tested it in a different branch I'm working on that consumes winrt_gen with some custom idls/winmds.