### PR TITLE
Implement factory caching

### DIFF
--- a/crates/gen/src/types/class.rs
+++ b/crates/gen/src/types/class.rs
@@ -1,8 +1,8 @@
 use super::object::to_object_tokens;
+use crate::format_ident;
 use crate::tables::*;
 use crate::types::*;
 use crate::TypeReader;
-use crate::*;
 use proc_macro2::TokenStream;
 use quote::quote;
 use std::iter::FromIterator;
@@ -256,6 +256,7 @@ impl Class {
 
             let interface_namespace =
                 to_namespace_tokens(&interface.name.namespace, &self.name.namespace);
+
             let interface_name = format_ident(&interface.name.name);
             let interface_tokens = quote! { #interface_namespace #interface_name };
             tokens.push(self.to_named_call_factory(&interface.name.name, &interface_tokens));
@@ -267,6 +268,7 @@ impl Class {
     fn to_named_call_factory(&self, method_name: &str, interface: &TokenStream) -> TokenStream {
         let self_name = &self.name.tokens;
         let method_name = format_ident(method_name);
+
         quote! {
             #[allow(non_snake_case)]
             fn #method_name<R, F: FnOnce(&#interface) -> ::winrt::Result<R>>(

--- a/crates/gen/src/types/method.rs
+++ b/crates/gen/src/types/method.rs
@@ -224,7 +224,7 @@ impl Method {
         let params = to_param_tokens(&self.params);
         let constraints = to_constraint_tokens(&self.params);
         let args = to_arg_tokens(&self.params);
-        let interface = &interface.name.tokens;
+        let interface = format_ident(&interface.name.name);
 
         let return_type = if let Some(return_type) = &self.return_type {
             return_type.to_return_tokens()
@@ -234,21 +234,21 @@ impl Method {
 
         quote! {
             pub fn #method_name<#constraints>(#params) -> ::winrt::Result<#return_type> {
-                ::winrt::factory::<Self, #interface>()?.#method_name(#args)
+                Self::#interface(|f| f.#method_name(#args))
             }
         }
     }
 
     pub fn to_composable_tokens(&self, interface: &RequiredInterface) -> TokenStream {
         let method_name = format_ident(&self.name);
-        let interface = &interface.name.tokens;
+        let interface = format_ident(&interface.name.name);
 
         if self.params.len() == 2 {
             // For non-aggregation scenarios this is just a default constructor, hence the
             // "new" method name in line with non-composable default constructors.
             quote! {
                 pub fn new() -> ::winrt::Result<Self> {
-                    ::winrt::factory::<Self, #interface>()?.#method_name(::winrt::Object::default(), &mut ::winrt::Object::default())
+                    Self::#interface(|f| f.#method_name(::winrt::Object::default(), &mut ::winrt::Object::default()))
                 }
             }
         } else {
@@ -259,7 +259,7 @@ impl Method {
 
             quote! {
                 pub fn #method_name<#constraints>(#params) -> ::winrt::Result<Self> {
-                    ::winrt::factory::<Self, #interface>()?.#method_name(#args ::winrt::Object::default(), &mut ::winrt::Object::default())
+                    Self::#interface(|f| f.#method_name(#args ::winrt::Object::default(), &mut ::winrt::Object::default()))
                 }
             }
         }

--- a/src/com/interface.rs
+++ b/src/com/interface.rs
@@ -47,6 +47,12 @@ pub unsafe trait ComInterface: Sized + crate::AbiTransferable {
         self.as_iunknown().is_none()
     }
 
+    /// Check whether the ComInterface is agile.
+    fn is_agile(&self) -> bool {
+        let agile: IAgileObject = self.query();
+        !agile.is_null()
+    }
+
     /// Query for a particular interface by iid.
     ///
     /// # Safety

--- a/src/error.rs
+++ b/src/error.rs
@@ -129,9 +129,6 @@ impl ErrorCode {
         Ok(op())
     }
 
-    /// Indicates that COM has not been initialized.
-    pub(crate) const NOT_INITIALIZED: ErrorCode = ErrorCode(0x8004_01F0);
-
     /// Creates a failure code from GetLastError()
     #[inline]
     pub(crate) fn last_win32_error() -> Self {

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -8,7 +8,7 @@ pub struct FactoryCache<C: RuntimeName, I: ComInterface> {
     pub _i: PhantomData<I>,
 }
 
-impl<C: RuntimeName, I: ComInterface> FactoryCache<C, I> {
+impl<C: RuntimeName, I: ComInterface + Default> FactoryCache<C, I> {
     pub fn new() -> Self {
         Self {
             shared: AtomicPtr::new(std::ptr::null_mut()),
@@ -18,79 +18,24 @@ impl<C: RuntimeName, I: ComInterface> FactoryCache<C, I> {
     }
 
     pub fn call<R, F: FnOnce(&I) -> Result<R>>(&mut self, callback: F) -> Result<R> {
-        loop {
-            unsafe {
-                let mut ptr = self.shared.load(Ordering::Relaxed);
+        unsafe {
+            loop {
+                let ptr = self.shared.load(Ordering::Relaxed);
 
                 if !ptr.is_null() {
                     return callback(std::mem::transmute(&ptr));
                 }
 
-                let name = HString::from(C::NAME);
-
-                let mut code = RoGetActivationFactory(name.get_abi(), &I::iid(), &mut ptr)
-                    .unwrap_or_else(|code| code);
-
-                if code == NOT_INITIALIZED {
-                    let mut cookie = std::ptr::null_mut();
-                    let _ = CoIncrementMTAUsage(&mut cookie);
-
-                    code = RoGetActivationFactory(name.get_abi(), &I::iid(), &mut ptr)
-                        .unwrap_or_else(|code| code);
-                }
-
-                if !code.is_ok() {
-                    let original: Error = code.into();
-                    let mut path = C::NAME;
-
-                    while let Some(pos) = path.rfind('.') {
-                        path = &path[..pos];
-
-                        let path: Vec<u16> =
-                            path.encode_utf16().chain(".dll\0".encode_utf16()).collect();
-
-                        let library = Library::from_handle(LoadLibraryExW(
-                            path.as_ptr(),
-                            std::ptr::null_mut(),
-                            0,
-                        ));
-
-                        if library.handle.is_null() {
-                            continue;
-                        }
-
-                        let library_call =
-                            GetProcAddress(library.handle, b"DllGetActivationFactory\0".as_ptr());
-
-                        if library_call.is_null() {
-                            continue;
-                        }
-
-                        let library_call: DllGetActivationFactory =
-                            std::mem::transmute(library_call);
-
-                        let mut factory: IActivationFactory = std::mem::zeroed();
-
-                        if library_call(name.get_abi() as _, factory.set_abi()).is_err() {
-                            continue;
-                        }
-
-                        std::mem::forget(library);
-                        let factory = factory.as_iunknown().unwrap();
-                        (factory.vtable().unknown_query_interface)(factory, &I::iid(), &mut ptr);
-                    }
-
-                    if ptr.is_null() {
-                        return Err(original);
-                    }
-                }
-
-                let factory: I = std::mem::transmute_copy(&ptr);
+                let factory = factory::<C, I>()?;
 
                 if factory.is_agile() {
                     if self
                         .shared
-                        .compare_and_swap(std::ptr::null_mut(), ptr, Ordering::Relaxed)
+                        .compare_and_swap(
+                            std::ptr::null_mut(),
+                            std::mem::transmute_copy(&factory),
+                            Ordering::Relaxed,
+                        )
                         .is_null()
                     {
                         std::mem::forget(factory);

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -16,7 +16,7 @@ impl<C: RuntimeName, I: ComInterface> FactoryCache<C, I> {
             _i: PhantomData,
         }
     }
-    
+
     pub fn call<R, F: FnOnce(&I) -> Result<R>>(&mut self, callback: F) -> Result<R> {
         loop {
             unsafe {
@@ -27,7 +27,7 @@ impl<C: RuntimeName, I: ComInterface> FactoryCache<C, I> {
                 }
 
                 let name = HString::from(C::NAME);
-                
+
                 let mut code = RoGetActivationFactory(name.get_abi(), &I::iid(), &mut ptr)
                     .unwrap_or_else(|code| code);
 
@@ -94,9 +94,9 @@ impl<C: RuntimeName, I: ComInterface> FactoryCache<C, I> {
                         .is_null()
                     {
                         std::mem::forget(factory);
-                    } else {
-                        return callback(&factory);
                     }
+                } else {
+                    return callback(&factory);
                 }
             }
         }
@@ -154,10 +154,7 @@ pub fn factory<C: RuntimeName, I: ComInterface + Default>() -> Result<I> {
             path = &path[..pos];
 
             // Turn the resulting namespace portion into a DLL name.
-            let path: Vec<u16> = path
-                .encode_utf16()
-                .chain(".dll\0".encode_utf16())
-                .collect();
+            let path: Vec<u16> = path.encode_utf16().chain(".dll\0".encode_utf16()).collect();
 
             // Attempt to load the DLL.
             let library =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@ pub use array::Array;
 pub use com::*;
 pub use error::*;
 #[doc(hidden)]
-pub use factory::factory;
+pub use factory::{factory, FactoryCache};
 #[doc(hidden)]
 pub use guid::Guid;
 pub use hstring::HString;

--- a/tests/uri.rs
+++ b/tests/uri.rs
@@ -23,6 +23,7 @@ fn uri() -> winrt::Result<()> {
 
     let uri = &Uri::create_uri("http://kennykerr.ca")?;
 
+    assert!(uri.is_agile());
     assert!(uri.domain()? == "kennykerr.ca");
     assert!(uri.port()? == 80);
 


### PR DESCRIPTION
The fixes #114 to add support for factory caching, a very important optimization that speeds up access to the static/constructor methods of a class. 

The `windows::ui::Colors` class provides a set of static methods that are useful for testing this. Here's a simple example:

```rust
use windows::ui::*;
use winrt::*;

fn main() -> Result<()> {
    {
        let start = std::time::Instant::now();

        for _ in 0..1_000_000 {
            let white = Colors::white()?;

            debug_assert!(
                white
                    == Color {
                        a: 255,
                        r: 255,
                        g: 255,
                        b: 255
                    }
            );
        }

        println!("single {:5}ms", start.elapsed().as_millis());
    }

    {
        let start = std::time::Instant::now();
        let mut threads = Vec::new();

        for _ in 0..16 {
            threads.push(std::thread::spawn(|| {
                for _ in 0..1_000_000 {
                    let white = Colors::white().unwrap();

                    debug_assert!(
                        white
                            == Color {
                                a: 255,
                                r: 255,
                                g: 255,
                                b: 255
                            }
                    );
                }
            }));
        }

        for thread in threads {
            thread.join().unwrap();
        }

        println!("multi  {:5}ms", start.elapsed().as_millis());
    }

    Ok(())
}
```

Here are the results without caching:

```
C:\git\rust\scratch>cargo run --release
    Finished release [optimized] target(s) in 0.22s
     Running `target\release\scratch.exe`
single   639ms
multi   7229ms
```

And here are the results with caching:

```
C:\git\rust\scratch>cargo run --release
    Finished release [optimized] target(s) in 0.12s
     Running `target\release\scratch.exe`
single    24ms
multi     21ms
```