### PR TITLE
Remove all codegen time guid generation

### DIFF
--- a/crates/gen/src/gen/interface.rs
+++ b/crates/gen/src/gen/interface.rs
@@ -7,7 +7,6 @@ pub struct Interface {
     pub name: gen::TypeName,
     pub guid: gen::TypeGuid,
     pub interfaces: Vec<gen::RequiredInterface>,
-    pub signature: String,
 }
 
 impl Interface {
@@ -24,13 +23,11 @@ impl Interface {
         );
 
         gen::add_dependencies(&mut interfaces, reader, &name, &name.namespace, true);
-        let signature = name.base_interface_signature(reader);
 
         Self {
             name,
             guid,
             interfaces,
-            signature,
         }
     }
 
@@ -69,8 +66,8 @@ impl Interface {
         let constraints = self.name.gen_constraint();
 
         let default_interface = self.default_interface();
-
         let guid = self.name.gen_guid(&self.guid);
+        let signature = self.name.gen_signature(&format!("{{{:#?}}}", &self.guid));
 
         let conversions = TokenStream::from_iter(
             self.interfaces
@@ -82,7 +79,6 @@ impl Interface {
         let methods = gen::gen_method(&self.interfaces);
         let abi_methods = default_interface.gen_abi_method();
         let iterator = gen::gen_iterator(&self.name, &self.interfaces);
-        let signature = self.name.gen_signature(&self.signature);
         let (async_get, future) = gen::gen_async(&self.name, &self.interfaces);
         let debug = gen::gen_debug(&self.name, &self.interfaces);
 

--- a/crates/gen/src/gen/interface.rs
+++ b/crates/gen/src/gen/interface.rs
@@ -5,12 +5,14 @@ use std::iter::FromIterator;
 #[derive(Debug)]
 pub struct Interface {
     pub name: gen::TypeName,
+    pub guid: gen::TypeGuid,
     pub interfaces: Vec<gen::RequiredInterface>,
     pub signature: String,
 }
 
 impl Interface {
     pub fn from_type_name(reader: &TypeReader, name: gen::TypeName) -> Self {
+        let guid = gen::TypeGuid::from_type_def(reader, name.def);
         let mut interfaces = Vec::new();
 
         gen::add_type(
@@ -26,6 +28,7 @@ impl Interface {
 
         Self {
             name,
+            guid,
             interfaces,
             signature,
         }
@@ -67,7 +70,7 @@ impl Interface {
 
         let default_interface = self.default_interface();
 
-        let guid = self.name.gen_guid(&default_interface.guid);
+        let guid = self.name.gen_guid(&self.guid);
 
         let conversions = TokenStream::from_iter(
             self.interfaces
@@ -164,6 +167,7 @@ mod tests {
         let t = interface(("Windows.Foundation", "IStringable"));
         assert!(t.name.runtime_name() == "Windows.Foundation.IStringable");
         assert!(t.interfaces.len() == 1);
+        assert!(format!("{:#?}", &t.guid) == "96369f54-8eb6-48f0-abce-c1b211e627c3");
 
         let t = t
             .interfaces
@@ -182,8 +186,6 @@ mod tests {
         assert!(method.params.is_empty());
         let param = method.return_type.as_ref().unwrap();
         assert!(param.kind == gen::TypeKind::String);
-
-        assert!(format!("{:#?}", &t.guid) == "96369f54-8eb6-48f0-abce-c1b211e627c3");
     }
 
     #[test]

--- a/crates/gen/src/gen/required_interface.rs
+++ b/crates/gen/src/gen/required_interface.rs
@@ -6,7 +6,6 @@ use std::iter::FromIterator;
 #[derive(Debug)]
 pub struct RequiredInterface {
     pub name: gen::TypeName,
-    pub guid: gen::TypeGuid,
     pub methods: Vec<gen::Method>,
     pub kind: InterfaceKind,
 }
@@ -19,7 +18,6 @@ impl RequiredInterface {
         kind: InterfaceKind,
     ) -> Self {
         let name = gen::TypeName::from_type_def(reader, def, calling_namespace);
-        let guid = gen::TypeGuid::from_type_def(reader, def);
 
         let mut methods = def
             .methods(reader)
@@ -32,7 +30,6 @@ impl RequiredInterface {
 
         Self {
             name,
-            guid,
             methods,
             kind,
         }
@@ -42,11 +39,8 @@ impl RequiredInterface {
         reader: &TypeReader,
         name: gen::TypeName,
         kind: InterfaceKind,
-        generics: bool,
         calling_namespace: &str,
     ) -> Self {
-        let guid = name.guid(reader, generics);
-
         let mut methods = name
             .def
             .methods(reader)
@@ -59,7 +53,6 @@ impl RequiredInterface {
 
         Self {
             name,
-            guid,
             methods,
             kind,
         }
@@ -148,8 +141,6 @@ pub fn add_dependencies(
     calling_namespace: &str,
     strip_default: bool,
 ) {
-    let generics = !name.generics.is_empty();
-
     for required in name.def.interfaces(reader) {
         let is_default = required.is_default(reader);
         let required = required.interface(reader);
@@ -184,7 +175,6 @@ pub fn add_dependencies(
                 reader,
                 required_name,
                 kind,
-                generics,
                 calling_namespace,
             ));
         }

--- a/crates/gen/src/gen/type_name.rs
+++ b/crates/gen/src/gen/type_name.rs
@@ -144,6 +144,7 @@ impl TypeName {
 
     pub fn gen_signature(&self, signature: &str) -> TokenStream {
         let signature = Literal::byte_string(signature.as_bytes());
+
         if self.generics.is_empty() {
             return quote! { ::winrt::ConstBuffer::from_slice(#signature) };
         }
@@ -163,6 +164,7 @@ impl TypeName {
                 #semi
             }
         });
+
         quote! {
             let string = ::winrt::ConstBuffer::new();
             let string = string.push_slice(b"pinterface(");
@@ -187,11 +189,6 @@ impl TypeName {
         quote! {
             ::winrt::Guid::from_signature(<#typ as ::winrt::RuntimeType>::SIGNATURE)
         }
-    }
-
-    pub fn base_interface_signature(&self, reader: &TypeReader) -> String {
-        let guid = gen::TypeGuid::from_type_def(reader, self.def);
-        format!("{{{:#?}}}", guid)
     }
 
     pub fn interface_signature(&self, reader: &TypeReader) -> String {
@@ -270,14 +267,6 @@ impl TypeName {
 
         result.push(')');
         result
-    }
-
-    pub fn base_delegate_signature(&self, reader: &TypeReader) -> String {
-        if self.generics.is_empty() {
-            format!("delegate({})", self.base_interface_signature(reader))
-        } else {
-            self.base_interface_signature(reader)
-        }
     }
 
     pub fn delegate_signature(&self, reader: &TypeReader) -> String {

--- a/crates/gen/src/gen/type_name.rs
+++ b/crates/gen/src/gen/type_name.rs
@@ -189,44 +189,6 @@ impl TypeName {
         }
     }
 
-    // TODO: get rid of this and do all calculations at initialization time
-    pub fn guid(&self, reader: &TypeReader, generics: bool) -> gen::TypeGuid {
-        if self.generics.is_empty() || generics {
-            return gen::TypeGuid::from_type_def(reader, self.def);
-        }
-
-        let mut data = vec![
-            0x11, 0xf4, 0x7a, 0xd5, 0x7b, 0x73, 0x42, 0xc0, 0xab, 0xae, 0x87, 0x8b, 0x1e, 0x16,
-            0xad, 0xee,
-        ];
-        data.extend_from_slice(self.interface_signature(reader).as_bytes());
-
-        let mut hash = sha1::Sha1::new();
-        hash.update(&data);
-        let bytes = hash.digest().bytes();
-
-        let first = u32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
-        let second = u16::from_be_bytes([bytes[4], bytes[5]]);
-        let mut third = u16::from_be_bytes([bytes[6], bytes[7]]);
-
-        third = (third & 0x0fff) | (5 << 12);
-        let fourth = (bytes[8] & 0x3f) | 0x80;
-
-        gen::TypeGuid([
-            gen::GuidConstant::U32(first),
-            gen::GuidConstant::U16(second),
-            gen::GuidConstant::U16(third),
-            gen::GuidConstant::U8(fourth),
-            gen::GuidConstant::U8(bytes[9]),
-            gen::GuidConstant::U8(bytes[10]),
-            gen::GuidConstant::U8(bytes[11]),
-            gen::GuidConstant::U8(bytes[12]),
-            gen::GuidConstant::U8(bytes[13]),
-            gen::GuidConstant::U8(bytes[14]),
-            gen::GuidConstant::U8(bytes[15]),
-        ])
-    }
-
     pub fn base_interface_signature(&self, reader: &TypeReader) -> String {
         let guid = gen::TypeGuid::from_type_def(reader, self.def);
         format!("{{{:#?}}}", guid)
@@ -507,49 +469,6 @@ mod tests {
         assert_eq!(
             type_name.runtime_name(),
             String::from("Outer.Inner.MyType<Boolean, UInt8>")
-        );
-    }
-
-    #[test]
-    fn guids() {
-        let reader = &TypeReader::from_os();
-
-        // Non-generic interface guid
-        let def = reader.resolve_type_def(("Windows.Foundation", "IAsyncAction"));
-        let name = gen::Type::from_type_def(reader, def).name().clone();
-        assert!(
-            format!("{{{:#?}}}", name.guid(reader, false))
-                == "{5a648006-843a-4da9-865b-9d26e5dfad7b}"
-        );
-
-        // Generic interface guid
-        let stringable = reader.resolve_type_def(("Windows.Foundation", "IStringable"));
-        let stringable = gen::Type::from_type_def(reader, stringable).name().clone();
-        let def = reader.resolve_type_def(("Windows.Foundation.Collections", "IVector`1"));
-        let mut name = gen::Type::from_type_def(reader, def).name().clone();
-        name.generics.clear();
-        name.generics.push(gen::TypeKind::Interface(stringable));
-        assert!(
-            format!("{{{:#?}}}", name.guid(reader, false))
-                == "{14b954c2-2914-530e-84a7-9473e2fb24e2}"
-        );
-
-        // Generic interface guid
-        let stringable = reader.resolve_type_def(("Windows.Foundation", "IWwwFormUrlDecoderEntry"));
-        let stringable = gen::Type::from_type_def(reader, stringable).name().clone();
-        let def = reader.resolve_type_def(("Windows.Foundation.Collections", "IVectorView`1"));
-        let mut name = gen::Type::from_type_def(reader, def).name().clone();
-        name.generics.clear();
-        name.generics.push(gen::TypeKind::Interface(stringable));
-        let guid = name.guid(reader, false);
-        assert!(format!("{{{:#?}}}", guid) == "{b1f00d3b-1f06-5117-93ea-2a0d79116701}");
-
-        // Unspecialized generic guid
-        let def = reader.resolve_type_def(("Windows.Foundation.Collections", "IVector`1"));
-        let name = gen::Type::from_type_def(reader, def).name().clone();
-        assert!(
-            format!("{{{:#?}}}", name.guid(reader, true))
-                == "{913337e9-11a1-4345-a3a2-4e7f956e222d}"
         );
     }
 

--- a/tests/delegates.rs
+++ b/tests/delegates.rs
@@ -28,7 +28,7 @@ fn non_generic() -> winrt::Result<()> {
         Ok(())
     });
 
-    // TODO: delegates are function objects (logically) ans we should be able
+    // TODO: delegates are function objects (logically) and we should be able
     // to call them without an explicit `invoke` method e.g. `d(args);`
     d.invoke(IAsyncAction::default(), AsyncStatus::Completed)?;
 
@@ -41,7 +41,10 @@ fn non_generic() -> winrt::Result<()> {
 fn generic() -> winrt::Result<()> {
     type Handler = TypedEventHandler<Uri, i32>;
 
-    // TODO: Handler::IID is not correct for generic types
+    assert_eq!(
+        Handler::IID,
+        winrt::Guid::from("DAE18EA9-FCF3-5ACF-BCDD-8C354CBA6D23")
+    );
 
     let d = Handler::default();
     assert!(d.is_null());


### PR DESCRIPTION
Now that generics guids are all calculated at build time with const functions, there is no need for codegen to do any of these calculations. Furthermore, only non-generic guids for top-level interfaces need to be retrieved from metadata.

This change simplifies but also reduces build time by about 14%.