### PR TITLE
Ignore multiple delegate assignment in async future polling

### DIFF
--- a/crates/gen/src/futures.rs
+++ b/crates/gen/src/futures.rs
@@ -87,10 +87,10 @@ fn gen_async_kind(
                     if self.status()? == ::winrt::foundation::AsyncStatus::Started {
                         let waker = context.waker().clone();
 
-                        self.set_completed(::winrt::foundation:: #handler::new(move |_sender, _args| {
+                        let _ = self.set_completed(::winrt::foundation:: #handler::new(move |_sender, _args| {
                             waker.wake_by_ref();
                             Ok(())
-                        }))?;
+                        }));
 
                         ::std::task::Poll::Pending
                     } else {


### PR DESCRIPTION
Fixes #322

While it is illegal to set a completed handler multiple times, it is safe to ignore the error. Given the following snippet:

```rust
async fn async_main() {
    let delay = vec![3000, 500, 2000, 1000];
    let futures = delay
        .iter()
        .map(|milliseconds| TestRunner::create_async_action(*milliseconds).unwrap());

    let results = join_all(futures).await;
    println!("{:?}", results);
}

fn main() {
    block_on(async_main())
}
```

I get the following output (instead of the previous error):

```
C:\git\scratch>cargo run
   Compiling scratch v0.1.0 (C:\git\scratch)
    Finished dev [unoptimized + debuginfo] target(s) in 1.05s
     Running `target\debug\scratch.exe`
500
1000
2000
3000
[Ok(()), Ok(()), Ok(()), Ok(())]
```

The `create_async_action` coroutine prints out the delay right before returning, so you can see they're completing in the correct order and the `join_all` successfully waits for them all.