### PR TITLE
Add TryFrom<HString> for String 

### DIFF
--- a/src/hstring.rs
+++ b/src/hstring.rs
@@ -49,7 +49,7 @@ impl HString {
 
     /// Create a HString from a slice of 16 bit characters (wchars).
     pub fn from_wide(value: &[u16]) -> HString {
-        unsafe { HString::from_wide_iter(value.iter().copied(), value.len() as u32) }
+        HString::from_wide_iter(value.iter().copied(), value.len() as u32)
     }
 
     /// Get the contents of this HString as a String lossily.
@@ -78,9 +78,7 @@ impl HString {
         self.ptr = std::ptr::null_mut();
     }
 
-    /// # Safety
-    /// len must not be less than the number of items in the iterator.
-    unsafe fn from_wide_iter<I: Iterator<Item = u16>>(iter: I, len: u32) -> HString {
+    fn from_wide_iter<I: Iterator<Item = u16>>(iter: I, len: u32) -> HString {
         if len == 0 {
             return HString::new();
         }
@@ -90,12 +88,18 @@ impl HString {
         // Place each utf-16 character into the buffer and
         // increase len as we go along.
         for (index, wide) in iter.enumerate() {
-            std::ptr::write((*ptr).data.add(index), wide);
-            (*ptr).len = index as u32 + 1;
+            debug_assert!((index as u32) < len);
+
+            unsafe {
+                std::ptr::write((*ptr).data.add(index), wide);
+                (*ptr).len = index as u32 + 1;
+            }
         }
 
         // Write a 0 byte to the end of the buffer.
-        std::ptr::write((*ptr).data.offset((*ptr).len as isize), 0);
+        unsafe {
+            std::ptr::write((*ptr).data.offset((*ptr).len as isize), 0);
+        }
         Self { ptr }
     }
 }
@@ -159,7 +163,7 @@ impl std::fmt::Debug for HString {
 
 impl From<&str> for HString {
     fn from(value: &str) -> Self {
-        unsafe { HString::from_wide_iter(value.encode_utf16(), value.len() as u32) }
+        HString::from_wide_iter(value.encode_utf16(), value.len() as u32)
     }
 }
 

--- a/src/hstring.rs
+++ b/src/hstring.rs
@@ -1,4 +1,6 @@
 use crate::*;
+use std::convert::TryFrom;
+use std::result::Result as StdResult;
 
 /// A WinRT string, sometimes called an [HSTRING](https://docs.microsoft.com/en-us/windows/win32/winrt/hstring).
 ///
@@ -189,15 +191,19 @@ impl PartialEq<HString> for &str {
     }
 }
 
-impl<'a> From<&'a HString> for String {
-    fn from(hstring: &HString) -> Self {
-        String::from_utf16(hstring.as_wide()).unwrap()
+impl<'a> TryFrom<&'a HString> for String {
+    type Error = std::string::FromUtf16Error;
+
+    fn try_from(hstring: &HString) -> StdResult<Self, Self::Error> {
+        String::from_utf16(hstring.as_wide())
     }
 }
 
-impl From<HString> for String {
-    fn from(hstring: HString) -> Self {
-        String::from(&hstring)
+impl TryFrom<HString> for String {
+    type Error = std::string::FromUtf16Error;
+
+    fn try_from(hstring: HString) -> StdResult<Self, Self::Error> {
+        String::try_from(&hstring)
     }
 }
 
@@ -332,7 +338,7 @@ mod tests {
     #[test]
     fn hstring_to_string() {
         let h = HString::from("test");
-        let s = String::from(h);
+        let s = String::try_from(h).unwrap();
         assert!(s == "test");
     }
 }

--- a/src/hstring.rs
+++ b/src/hstring.rs
@@ -52,6 +52,11 @@ impl HString {
         HString::from_wide_iter(value.iter().copied(), value.len() as u32)
     }
 
+    /// Get the contents of this HString as a String lossily.
+    pub fn to_string_lossy(&self) -> String {
+        String::from_utf16_lossy(self.as_wide())
+    }
+
     /// Clear the contents of the string and free the memory if `self` holds the
     /// last reference to the string data.
     pub fn clear(&mut self) {
@@ -360,5 +365,14 @@ mod tests {
         let h = HString::from_wide(wide_data);
         let err = String::try_from(h);
         assert!(err.is_err());
+    }
+
+    #[test]
+    fn hstring_to_string_lossy() {
+        // 𝄞mu<invalid>ic
+        let wide_data = &[0xD834, 0xDD1E, 0x006d, 0x0075, 0xD800, 0x0069, 0x0063];
+        let h = HString::from_wide(wide_data);
+        let s = h.to_string_lossy();
+        assert_eq!(s, "𝄞mu�ic");
     }
 }

--- a/src/hstring.rs
+++ b/src/hstring.rs
@@ -352,4 +352,13 @@ mod tests {
         let s = String::try_from(h).unwrap();
         assert!(s == "test");
     }
+
+    #[test]
+    fn hstring_to_string_err() {
+        // 𝄞mu<invalid>ic
+        let wide_data = &[0xD834, 0xDD1E, 0x006d, 0x0075, 0xD800, 0x0069, 0x0063];
+        let h = HString::from_wide(wide_data);
+        let err = String::try_from(h);
+        assert!(err.is_err());
+    }
 }

--- a/src/hstring.rs
+++ b/src/hstring.rs
@@ -49,7 +49,7 @@ impl HString {
 
     /// Create a HString from a slice of 16 bit characters (wchars).
     pub fn from_wide(value: &[u16]) -> HString {
-        HString::from_wide_iter(value.iter().copied(), value.len() as u32)
+        unsafe { HString::from_wide_iter(value.iter().copied(), value.len() as u32) }
     }
 
     /// Get the contents of this HString as a String lossily.
@@ -78,7 +78,9 @@ impl HString {
         self.ptr = std::ptr::null_mut();
     }
 
-    fn from_wide_iter<I: Iterator<Item = u16>>(iter: I, len: u32) -> HString {
+    /// # Safety
+    /// len must not be less than the number of items in the iterator.
+    unsafe fn from_wide_iter<I: Iterator<Item = u16>>(iter: I, len: u32) -> HString {
         if len == 0 {
             return HString::new();
         }
@@ -90,16 +92,12 @@ impl HString {
         for (index, wide) in iter.enumerate() {
             debug_assert!((index as u32) < len);
 
-            unsafe {
-                std::ptr::write((*ptr).data.add(index), wide);
-                (*ptr).len = index as u32 + 1;
-            }
+            std::ptr::write((*ptr).data.add(index), wide);
+            (*ptr).len = index as u32 + 1;
         }
 
         // Write a 0 byte to the end of the buffer.
-        unsafe {
-            std::ptr::write((*ptr).data.offset((*ptr).len as isize), 0);
-        }
+        std::ptr::write((*ptr).data.offset((*ptr).len as isize), 0);
         Self { ptr }
     }
 }
@@ -163,7 +161,7 @@ impl std::fmt::Debug for HString {
 
 impl From<&str> for HString {
     fn from(value: &str) -> Self {
-        HString::from_wide_iter(value.encode_utf16(), value.len() as u32)
+        unsafe { HString::from_wide_iter(value.encode_utf16(), value.len() as u32) }
     }
 }
 


### PR DESCRIPTION
Closes #227.

I removed the implementation of `From<HString>` for `String` and replaced it with a `TryFrom<HString>`, modifying the existing tests accordingly. In order to add a new basic test for this new `TryFrom` impl, I created a constructor called `from_wide` that creates a `HString` from a slice of `u16`s. To reduce code duplication, I extracted most of the logic from `From<&str>` and put it in a new private constructor. I added the `to_string_lossy` method to `HString` to allow easier lossy conversions between `HString` and `String`, as well as a basic test for this functionality.

I refrained from adding a fallible `to_string` method as that would conflict with the `Display` trait that is implemented for `HString`. I felt the name `to_str` also wouldn't make sense here as this method would be forced to return a `String` as the internal data is not utf8. I was also unsure of the importance of such a method as the new `TryFrom<HString>` impl now exists, so I excluded it from this PR.