### PR TITLE
Use full paths when implementing interfaces

### DIFF
--- a/crates/gen/src/delegate.rs
+++ b/crates/gen/src/delegate.rs
@@ -46,7 +46,7 @@ impl Delegate {
             self.name.gen_signature(&format!("{{{:#?}}}", &self.guid))
         };
 
-        let invoke_upcall = self.method.gen_upcall(quote! { ((*this).invoke) });
+        let invoke_upcall = self.method.gen_upcall(quote! { ((*this).invoke) }, true);
 
         quote! {
             #[repr(transparent)]

--- a/crates/gen/src/method.rs
+++ b/crates/gen/src/method.rs
@@ -235,8 +235,11 @@ impl Method {
         }
     }
 
-    pub fn gen_upcall(&self, inner: TokenStream) -> TokenStream {
-        let invoke_args = self.params.iter().map(|param| param.gen_invoke_arg());
+    pub fn gen_upcall(&self, inner: TokenStream, relative: bool) -> TokenStream {
+        let invoke_args = self
+            .params
+            .iter()
+            .map(|param| param.gen_invoke_arg(relative));
 
         match &self.return_type {
             Some(return_type) if return_type.array => {

--- a/crates/gen/src/param.rs
+++ b/crates/gen/src/param.rs
@@ -171,9 +171,14 @@ impl Param {
         }
     }
 
-    pub fn gen_invoke_arg(&self) -> TokenStream {
+    pub fn gen_invoke_arg(&self, relative: bool) -> TokenStream {
         let name = format_ident(&self.name);
-        let kind = self.kind.gen();
+
+        let kind = if relative {
+            self.kind.gen()
+        } else {
+            self.kind.gen_full()
+        };
 
         // TODO: This compiles but doesn't property handle delegates with array parameters.
         // https://github.com/microsoft/winrt-rs/issues/212

--- a/crates/gen/src/type_kind.rs
+++ b/crates/gen/src/type_kind.rs
@@ -240,6 +240,35 @@ impl TypeKind {
         }
     }
 
+    pub fn gen_full(&self) -> TokenStream {
+        match self {
+            Self::Bool => quote! { bool },
+            Self::Char => quote! { u16 },
+            Self::I8 => quote! { i8 },
+            Self::U8 => quote! { u8 },
+            Self::I16 => quote! { i16 },
+            Self::U16 => quote! { u16 },
+            Self::I32 => quote! { i32 },
+            Self::U32 => quote! { u32 },
+            Self::I64 => quote! { i64 },
+            Self::U64 => quote! { u64 },
+            Self::F32 => quote! { f32 },
+            Self::F64 => quote! { f64 },
+            Self::String => quote! { ::winrt::HString },
+            Self::Object => quote! { ::winrt::Object },
+            Self::Guid => quote! { ::winrt::Guid },
+            Self::Class(name) => name.gen_full(),
+            Self::Interface(name) => name.gen_full(),
+            Self::Enum(name) => name.gen_full(),
+            Self::Struct(name) => name.gen_full(),
+            Self::Delegate(name) => name.gen_full(),
+            Self::Generic(name) => {
+                let name = format_ident(name);
+                quote! { #name }
+            }
+        }
+    }
+
     pub fn gen_field(&self) -> TokenStream {
         let mut tokens = self.gen();
 

--- a/crates/macros/src/implement.rs
+++ b/crates/macros/src/implement.rs
@@ -184,7 +184,7 @@ pub fn gen(
                 });
 
                 let signature = method.gen_abi();
-                let upcall = method.gen_upcall(quote! { (*this).inner.#method_ident });
+                let upcall = method.gen_upcall(quote! { (*this).inner.#method_ident }, false);
 
                 shims.combine(&quote! {
                     unsafe extern "system" fn #vcall_ident #signature {

--- a/integration-tests/build.rs
+++ b/integration-tests/build.rs
@@ -23,5 +23,8 @@ fn main() {
             // Test for https://github.com/microsoft/winrt-rs/issues/280
             windows::application_model::email::EmailAttachment
             windows::storage::streams::{InMemoryRandomAccessStream, RandomAccessStreamReference}
+
+            // Test for https://github.com/microsoft/winrt-rs/issues/361
+            windows::ui::xaml::{IApplicationOverrides, IApplicationOverrides2}
     );
 }

--- a/integration-tests/tests/implement_overrides.rs
+++ b/integration-tests/tests/implement_overrides.rs
@@ -1,0 +1,82 @@
+use tests::*;
+
+#[test]
+fn overrides() {
+    let overrides: windows::ui::xaml::IApplicationOverrides = App {}.into();
+    overrides.on_activated(None).unwrap();
+}
+
+#[winrt::implement(windows::ui::xaml::{IApplicationOverrides, IApplicationOverrides2})]
+struct App {}
+
+impl App {
+    fn on_activated(
+        &self,
+        _args: &Option<windows::application_model::activation::IActivatedEventArgs>,
+    ) -> winrt::Result<()> {
+        Ok(())
+    }
+
+    fn on_launched(
+        &self,
+        _args: &Option<windows::application_model::activation::LaunchActivatedEventArgs>,
+    ) -> winrt::Result<()> {
+        Ok(())
+    }
+
+    fn on_file_activated(
+        &self,
+        _args: &Option<windows::application_model::activation::FileActivatedEventArgs>,
+    ) -> winrt::Result<()> {
+        Ok(())
+    }
+
+    fn on_search_activated(
+        &self,
+        _args: &Option<windows::application_model::activation::SearchActivatedEventArgs>,
+    ) -> winrt::Result<()> {
+        Ok(())
+    }
+
+    fn on_share_target_activated(
+        &self,
+        _args: &Option<windows::application_model::activation::ShareTargetActivatedEventArgs>,
+    ) -> winrt::Result<()> {
+        Ok(())
+    }
+
+    fn on_file_open_picker_activated(
+        &self,
+        _args: &Option<windows::application_model::activation::FileOpenPickerActivatedEventArgs>,
+    ) -> winrt::Result<()> {
+        Ok(())
+    }
+
+    fn on_file_save_picker_activated(
+        &self,
+        _args: &Option<windows::application_model::activation::FileSavePickerActivatedEventArgs>,
+    ) -> winrt::Result<()> {
+        Ok(())
+    }
+
+    fn on_cached_file_updater_activated(
+        &self,
+        _args: &Option<windows::application_model::activation::CachedFileUpdaterActivatedEventArgs>,
+    ) -> winrt::Result<()> {
+        Ok(())
+    }
+
+    fn on_window_created(
+        &self,
+        _args: &Option<windows::ui::xaml::WindowCreatedEventArgs>,
+    ) -> winrt::Result<()> {
+        Ok(())
+    }
+
+    fn on_background_activated(
+        &self,
+        _args: &Option<windows::application_model::activation::BackgroundActivatedEventArgs>,
+    ) -> winrt::Result<()> {
+        Ok(())
+    }
+}


### PR DESCRIPTION
Fixes #361 

With this change, you can now implement interfaces that refer to types in other namespaces/modules. Here's an example of implementing Xaml's `IApplicationOverrides` and `IApplicationOverrides2`.

```rust
use bindings::*;
use winrt::Result;
use windows::application_model::activation;

fn main() -> Result<()> {
    let app = App{};
    let overrides: windows::ui::xaml::IApplicationOverrides = app.into();
    overrides.on_activated(None)?;

    Ok(())
}

#[winrt::implement(windows::ui::xaml::{IApplicationOverrides, IApplicationOverrides2})]
struct App {
}

impl App {
    fn on_activated(&self, _args: &Option<activation::IActivatedEventArgs>) -> Result<()> {
        println!("on_activated");
        Ok(())
    }

    fn on_launched(&self, _args: &Option<activation::LaunchActivatedEventArgs>) -> Result<()> {
        Ok(())
    }

    fn on_file_activated(&self, _args: &Option<activation::FileActivatedEventArgs>) -> Result<()> {
        Ok(())
    }

    fn on_search_activated(&self, _args: &Option<activation::SearchActivatedEventArgs>) -> Result<()> {
        Ok(())
    }

    fn on_share_target_activated(&self, _args: &Option<activation::ShareTargetActivatedEventArgs>) -> Result<()> {
        Ok(())
    }

    fn on_file_open_picker_activated(&self, _args: &Option<activation::FileOpenPickerActivatedEventArgs>) -> Result<()> {
        Ok(())
    }

    fn on_file_save_picker_activated(&self, _args: &Option<activation::FileSavePickerActivatedEventArgs>) -> Result<()> {
        Ok(())
    }

    fn on_cached_file_updater_activated(&self, _args: &Option<activation::CachedFileUpdaterActivatedEventArgs>) -> Result<()> {
        Ok(())
    }

    fn on_window_created(&self, _args: &Option<windows::ui::xaml::WindowCreatedEventArgs>) -> Result<()> {
        Ok(())
    }

    fn on_background_activated(&self, _args: &Option<activation::BackgroundActivatedEventArgs>) -> Result<()> {
        Ok(())
    }
}
```

A few things to note about this example.

1. The `implement` macro has no way of knowing the name of the bindings crate so you need to use a `use` declaration to bring its contents into scope e.g. `use bindings::*;`

2. Although you can freely use additional `use` declarations to simplify the code you need write, you must use full type paths in the `implement` macro because again, the `implement` macro has no way of knowing about these `use` declarations and can only see its input token stream. 