### PR TITLE
copy files from .windows to root target directoty

### DIFF
--- a/crates/gen/Cargo.toml
+++ b/crates/gen/Cargo.toml
@@ -17,3 +17,4 @@ sha1 = "0.6.0"
 rayon = "1.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+lazy_static="1.4.0"

--- a/crates/gen/src/windows.rs
+++ b/crates/gen/src/windows.rs
@@ -1,7 +1,7 @@
 use lazy_static::lazy_static;
 
 /// Returns the build's `.windows` directory in the root of the workspace as a `PathBuf`.
-pub fn build_windows_dir() -> std::path::PathBuf {
+pub fn workspace_windows_dir() -> std::path::PathBuf {
     let mut path = WORKSPACE_DIR.clone();
     path.push(".windows");
     path

--- a/crates/gen/src/windows.rs
+++ b/crates/gen/src/windows.rs
@@ -8,7 +8,7 @@ pub fn build_windows_dir() -> std::path::PathBuf {
 }
 
 /// Returns the build's target directory in the passed workspace directory as a `PathBuf`.
-pub fn build_target_dir() -> std::path::PathBuf {
+pub fn workspace_target_dir() -> std::path::PathBuf {
     let mut path = WORKSPACE_DIR.clone();
     path.push("target");
     path

--- a/crates/gen/src/windows.rs
+++ b/crates/gen/src/windows.rs
@@ -1,11 +1,25 @@
 /// Returns the build's `.windows` directory in the root of the workspace as a `PathBuf`.
 pub fn build_windows_dir() -> std::path::PathBuf {
-    let mut path = workspace_dir();
+    build_windows_dir_at_workspace(&workspace_dir())
+}
+
+/// Returns the build's `.windows` directory in the passed workspace directory as a `PathBuf`.
+pub fn build_windows_dir_at_workspace(workspace_dir: &std::path::PathBuf) -> std::path::PathBuf {
+    let mut path = workspace_dir.clone();
     path.push(".windows");
     path
 }
 
-fn workspace_dir() -> std::path::PathBuf {
+/// Returns the build's target directory in the passed workspace directory as a `PathBuf`.
+pub fn build_target_dir_at_at_workspace(workspace_dir: &std::path::PathBuf) -> std::path::PathBuf {
+    let mut path = workspace_dir.clone();
+    path.push("target");
+    path
+}
+
+/// Returns the build's workspace directory. Executes 'cargo' command to get it because Cargo
+/// lacks an environment variable for the workspace dir.
+pub fn workspace_dir() -> std::path::PathBuf {
     // This is all rather complicated and expensive because Cargo lacks an environment variable for the workspace dir.
 
     let output = std::process::Command::new(env!("CARGO"))

--- a/crates/gen/src/windows.rs
+++ b/crates/gen/src/windows.rs
@@ -1,25 +1,24 @@
+use lazy_static::lazy_static;
+
 /// Returns the build's `.windows` directory in the root of the workspace as a `PathBuf`.
 pub fn build_windows_dir() -> std::path::PathBuf {
-    build_windows_dir_at_workspace(&workspace_dir())
-}
-
-/// Returns the build's `.windows` directory in the passed workspace directory as a `PathBuf`.
-pub fn build_windows_dir_at_workspace(workspace_dir: &std::path::PathBuf) -> std::path::PathBuf {
-    let mut path = workspace_dir.clone();
+    let mut path = WORKSPACE_DIR.clone();
     path.push(".windows");
     path
 }
 
 /// Returns the build's target directory in the passed workspace directory as a `PathBuf`.
-pub fn build_target_dir_at_workspace(workspace_dir: &std::path::PathBuf) -> std::path::PathBuf {
-    let mut path = workspace_dir.clone();
+pub fn build_target_dir() -> std::path::PathBuf {
+    let mut path = WORKSPACE_DIR.clone();
     path.push("target");
     path
 }
 
-/// Returns the build's workspace directory. Executes 'cargo' command to get it because Cargo
-/// lacks an environment variable for the workspace dir.
-pub fn workspace_dir() -> std::path::PathBuf {
+lazy_static! {
+    static ref WORKSPACE_DIR: std::path::PathBuf = workspace_dir();
+}
+
+fn workspace_dir() -> std::path::PathBuf {
     // This is all rather complicated and expensive because Cargo lacks an environment variable for the workspace dir.
 
     let output = std::process::Command::new(env!("CARGO"))

--- a/crates/gen/src/windows.rs
+++ b/crates/gen/src/windows.rs
@@ -11,7 +11,7 @@ pub fn build_windows_dir_at_workspace(workspace_dir: &std::path::PathBuf) -> std
 }
 
 /// Returns the build's target directory in the passed workspace directory as a `PathBuf`.
-pub fn build_target_dir_at_at_workspace(workspace_dir: &std::path::PathBuf) -> std::path::PathBuf {
+pub fn build_target_dir_at_workspace(workspace_dir: &std::path::PathBuf) -> std::path::PathBuf {
     let mut path = workspace_dir.clone();
     path.push("target");
     path

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -48,7 +48,7 @@ pub fn build(stream: TokenStream) -> TokenStream {
     source.push(ARCHITECTURE);
     let source = source.to_str().expect("Invalid build windows dir");
 
-    let destination = ::winrt_gen::build_target_dir_at_at_workspace(&workspace_dir);
+    let destination = ::winrt_gen::build_target_dir_at_workspace(&workspace_dir);
     let destination = destination.to_str().expect("Invalid build target dir");
 
     let tokens = quote! {

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -42,13 +42,11 @@ pub fn build(stream: TokenStream) -> TokenStream {
         Err(t) => return t.into(),
     };
 
-    let workspace_dir = ::winrt_gen::workspace_dir();
-
-    let mut source = ::winrt_gen::build_windows_dir_at_workspace(&workspace_dir);
+    let mut source = winrt_gen::build_windows_dir();
     source.push(ARCHITECTURE);
     let source = source.to_str().expect("Invalid build windows dir");
 
-    let destination = ::winrt_gen::build_target_dir_at_workspace(&workspace_dir);
+    let destination = winrt_gen::build_target_dir();
     let destination = destination.to_str().expect("Invalid build target dir");
 
     let tokens = quote! {

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -42,7 +42,7 @@ pub fn build(stream: TokenStream) -> TokenStream {
         Err(t) => return t.into(),
     };
 
-    let mut source = winrt_gen::build_windows_dir();
+    let mut source = winrt_gen::workspace_windows_dir();
     source.push(ARCHITECTURE);
     let source = source.to_str().expect("Invalid build windows dir");
 

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -46,7 +46,7 @@ pub fn build(stream: TokenStream) -> TokenStream {
     source.push(ARCHITECTURE);
     let source = source.to_str().expect("Invalid build windows dir");
 
-    let destination = winrt_gen::build_target_dir();
+    let destination = winrt_gen::workspace_target_dir();
     let destination = destination.to_str().expect("Invalid build target dir");
 
     let tokens = quote! {

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -42,9 +42,14 @@ pub fn build(stream: TokenStream) -> TokenStream {
         Err(t) => return t.into(),
     };
 
-    let mut source = ::winrt_gen::build_windows_dir();
+    let workspace_dir = ::winrt_gen::workspace_dir();
+
+    let mut source = ::winrt_gen::build_windows_dir_at_workspace(&workspace_dir);
     source.push(ARCHITECTURE);
     let source = source.to_str().expect("Invalid build windows dir");
+
+    let destination = ::winrt_gen::build_target_dir_at_at_workspace(&workspace_dir);
+    let destination = destination.to_str().expect("Invalid build target dir");
 
     let tokens = quote! {
         {
@@ -103,12 +108,11 @@ pub fn build(stream: TokenStream) -> TokenStream {
             }
 
             let profile = ::std::env::var("PROFILE").expect("No `PROFILE` env variable set");
-            let manifest_dir = ::std::env::var("CARGO_MANIFEST_DIR").expect("No `CARGO_MANIFEST_DIR` env variable set");
 
-            let mut destination = ::std::path::PathBuf::from(&manifest_dir);
-            destination.push("target");
+            let source = ::std::path::PathBuf::from(#source);
+            let destination = ::std::path::PathBuf::from(#destination);
 
-            copy_to_profile(&::std::path::PathBuf::from(#source), &destination, &profile);
+            copy_to_profile(&source, &destination, &profile);
 
         }
     };

--- a/crates/macros/src/windows.rs
+++ b/crates/macros/src/windows.rs
@@ -13,7 +13,7 @@ pub fn reader() -> &'static winmd::TypeReader {
 }
 
 fn winmd_paths() -> Vec<std::path::PathBuf> {
-    let mut windows_path = winrt_gen::build_windows_dir();
+    let mut windows_path = winrt_gen::workspace_windows_dir();
     windows_path.push("winmd");
 
     let mut paths = vec![];

--- a/crates/tests/tests/custom_attribute.rs
+++ b/crates/tests/tests/custom_attribute.rs
@@ -17,7 +17,7 @@ fn find_winmds<P: AsRef<Path>>(directory: P) -> Vec<PathBuf> {
 
 #[test]
 fn named_arguments() -> Result<()> {
-    let mut winmd_dir = winrt::build_windows_dir();
+    let mut winmd_dir = winrt::workspace_windows_dir();
     winmd_dir.push("winmd");
     let files = find_winmds(winmd_dir);
     let reader = winmd::TypeReader::from_iter(files);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ pub use result::{Error, ErrorCode, Result};
 pub use runtime::{Array, FactoryCache, Guid, Param, RefCount, Waiter};
 pub use strings::HString;
 pub use traits::{Abi, Interface, RuntimeName, RuntimeType};
-pub use winrt_gen::build_windows_dir;
+pub use winrt_gen::workspace_windows_dir;
 pub use winrt_macros::{build, implement};
 
 extern crate self as winrt;


### PR DESCRIPTION
This is a fix for issue https://github.com/microsoft/winrt-rs/issues/377
The problem is that CARGO_MANIFEST_DIR variable contains the path to Cargo.toml of subcrate, so script tries to copy files from ",windows" directory to "win2d-rs\bindings\target" instead of "win2d-rs\target"

Function workspace_dir() made public to avoid multiple call to it as it's quite expensive