### PR TITLE
Allow access to an enum's underlying value

### DIFF
--- a/crates/gen/src/enum.rs
+++ b/crates/gen/src/enum.rs
@@ -126,7 +126,7 @@ impl Enum {
         quote! {
             #[allow(non_camel_case_types)]
             #[repr(transparent)]
-            pub struct #name(#underlying_type);
+            pub struct #name(pub #underlying_type);
             impl ::std::convert::From<#underlying_type> for #name {
                 fn from(value: #underlying_type) -> Self {
                     Self(value)

--- a/crates/tests/tests/enum.rs
+++ b/crates/tests/tests/enum.rs
@@ -8,6 +8,12 @@ fn signed_enum() {
     assert!(AsyncStatus::Completed == 1.into());
     assert!(AsyncStatus::Error == 3.into());
     assert!(AsyncStatus::Started == 0.into());
+
+    assert!(AsyncStatus::default().0 == 0);
+    assert!(AsyncStatus::Canceled.0 == 2);
+    assert!(AsyncStatus::Completed.0 == 1);
+    assert!(AsyncStatus::Error.0 == 3);
+    assert!(AsyncStatus::Started.0 == 0);
 }
 
 #[test]
@@ -22,7 +28,18 @@ fn unsigned_enum() {
     assert!(AppointmentDaysOfWeek::Friday == 0x20.into());
     assert!(AppointmentDaysOfWeek::Saturday == 0x40.into());
 
+    assert!(AppointmentDaysOfWeek::default().0 == 0);
+    assert!(AppointmentDaysOfWeek::None.0 == 0);
+    assert!(AppointmentDaysOfWeek::Sunday.0 == 0x1);
+    assert!(AppointmentDaysOfWeek::Monday.0 == 0x2);
+    assert!(AppointmentDaysOfWeek::Tuesday.0 == 0x4);
+    assert!(AppointmentDaysOfWeek::Wednesday.0 == 0x8);
+    assert!(AppointmentDaysOfWeek::Thursday.0 == 0x10);
+    assert!(AppointmentDaysOfWeek::Friday.0 == 0x20);
+    assert!(AppointmentDaysOfWeek::Saturday.0 == 0x40);
+
     // Use as bitflags
     let weekend = AppointmentDaysOfWeek::Sunday | AppointmentDaysOfWeek::Saturday;
     assert!(weekend == 0x41.into());
+    assert!(weekend.0 == 0x41);
 }


### PR DESCRIPTION
This simplifies interop with Windows APIs.